### PR TITLE
Fix authentication headers for all API endpoints

### DIFF
--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -70,7 +70,8 @@ export const useRfidScanning = () => {
             action: 'checkin',
             room_id: selectedRoom.id,
           },
-          authenticatedUser.pin
+          authenticatedUser.pin,
+          authenticatedUser.staffId
         );
 
         logger.info(`Scan result: ${result.action} for ${result.student_name}`);
@@ -100,7 +101,7 @@ export const useRfidScanning = () => {
 
         // Update session activity to prevent timeout
         try {
-          await api.updateSessionActivity(authenticatedUser.pin);
+          await api.updateSessionActivity(authenticatedUser.pin, authenticatedUser.staffId);
           logger.debug('Session activity updated');
         } catch (error) {
           logger.warn('Failed to update session activity', { error });

--- a/src/pages/RoomSelectionPage.tsx
+++ b/src/pages/RoomSelectionPage.tsx
@@ -339,7 +339,7 @@ function RoomSelectionPage() {
         room_id: selectedRoom.id, // Manual room selection
       };
 
-      const sessionResponse = await api.startSession(authenticatedUser.pin, sessionRequest);
+      const sessionResponse = await api.startSession(authenticatedUser.pin, authenticatedUser.staffId, sessionRequest);
 
       performance.mark('session-start-end');
       performance.measure('session-start-duration', 'session-start-begin', 'session-start-end');
@@ -419,7 +419,7 @@ function RoomSelectionPage() {
         force: true, // Force override any conflicts
       };
 
-      const sessionResponse = await api.startSession(authenticatedUser.pin, forceSessionRequest);
+      const sessionResponse = await api.startSession(authenticatedUser.pin, authenticatedUser.staffId, forceSessionRequest);
 
       logger.info('Session started successfully with force override', {
         sessionId: sessionResponse.active_group_id,

--- a/src/pages/TagAssignmentPage.tsx
+++ b/src/pages/TagAssignmentPage.tsx
@@ -182,7 +182,7 @@ function TagAssignmentPage() {
       throw new Error('Keine Authentifizierung verfügbar');
     }
 
-    return await api.checkTagAssignment(authenticatedUser.pin, tagId);
+    return await api.checkTagAssignment(authenticatedUser.pin, authenticatedUser.staffId, tagId);
   };
 
   // Fetch teacher's students
@@ -191,7 +191,7 @@ function TagAssignmentPage() {
       throw new Error('Keine Authentifizierung verfügbar');
     }
 
-    return await api.getStudents(authenticatedUser.pin);
+    return await api.getStudents(authenticatedUser.pin, authenticatedUser.staffId);
   };
 
   // Assign tag to selected student
@@ -218,7 +218,7 @@ function TagAssignmentPage() {
       });
 
       // Call the actual API endpoint
-      const result = await api.assignTag(authenticatedUser.pin, selectedStudentId, scannedTag);
+      const result = await api.assignTag(authenticatedUser.pin, authenticatedUser.staffId, selectedStudentId, scannedTag);
 
       if (result.success) {
         const studentName = `${selectedStudent.first_name} ${selectedStudent.last_name}`;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -267,11 +267,12 @@ export const api = {
    * Get teacher's activities for today
    * Endpoint: GET /api/iot/activities
    */
-  async getActivities(pin: string): Promise<ActivityResponse[]> {
+  async getActivities(pin: string, staffId: number): Promise<ActivityResponse[]> {
     const response = await apiCall<ActivitiesResponse>('/api/iot/activities', {
       headers: {
         Authorization: `Bearer ${DEVICE_API_KEY}`,
         'X-Staff-PIN': pin,
+        'X-Staff-ID': staffId.toString(),
       },
     });
 
@@ -282,12 +283,13 @@ export const api = {
    * Device health ping
    * Endpoint: POST /api/iot/ping
    */
-  async pingDevice(pin: string): Promise<void> {
+  async pingDevice(pin: string, staffId: number): Promise<void> {
     await apiCall('/api/iot/ping', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${DEVICE_API_KEY}`,
         'X-Staff-PIN': pin,
+        'X-Staff-ID': staffId.toString(),
       },
     });
   },
@@ -296,7 +298,7 @@ export const api = {
    * Get available rooms (device authenticated)
    * Endpoint: GET /api/iot/rooms/available
    */
-  async getRooms(pin: string, capacity?: number): Promise<Room[]> {
+  async getRooms(pin: string, staffId: number, capacity?: number): Promise<Room[]> {
     const params = new URLSearchParams();
     if (capacity) {
       params.append('capacity', capacity.toString());
@@ -308,6 +310,7 @@ export const api = {
       headers: {
         Authorization: `Bearer ${DEVICE_API_KEY}`,
         'X-Staff-PIN': pin,
+        'X-Staff-ID': staffId.toString(),
       },
     });
 
@@ -318,7 +321,7 @@ export const api = {
    * Start activity session
    * Endpoint: POST /api/iot/session/start
    */
-  async startSession(pin: string, request: SessionStartRequest): Promise<SessionStartResponse> {
+  async startSession(pin: string, staffId: number, request: SessionStartRequest): Promise<SessionStartResponse> {
     logger.info('Starting session with request:', { ...request });
     
     const response = await apiCall<{
@@ -330,6 +333,7 @@ export const api = {
       headers: {
         Authorization: `Bearer ${DEVICE_API_KEY}`,
         'X-Staff-PIN': pin,
+        'X-Staff-ID': staffId.toString(),
       },
       body: JSON.stringify(request),
     });
@@ -341,7 +345,7 @@ export const api = {
    * Get current session for device
    * Endpoint: GET /api/iot/session/current
    */
-  async getCurrentSession(pin: string): Promise<CurrentSession | null> {
+  async getCurrentSession(pin: string, staffId: number): Promise<CurrentSession | null> {
     try {
       const response = await apiCall<{
         status: string;
@@ -351,6 +355,7 @@ export const api = {
         headers: {
           Authorization: `Bearer ${DEVICE_API_KEY}`,
           'X-Staff-PIN': pin,
+          'X-Staff-ID': staffId.toString(),
         },
       });
 
@@ -375,12 +380,13 @@ export const api = {
    * End current session
    * Endpoint: POST /api/iot/session/end
    */
-  async endSession(pin: string): Promise<void> {
+  async endSession(pin: string, staffId: number): Promise<void> {
     await apiCall('/api/iot/session/end', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${DEVICE_API_KEY}`,
         'X-Staff-PIN': pin,
+        'X-Staff-ID': staffId.toString(),
       },
     });
   },
@@ -389,7 +395,7 @@ export const api = {
    * Get teacher's students for tag assignment
    * Endpoint: GET /api/iot/students
    */
-  async getStudents(pin: string): Promise<Student[]> {
+  async getStudents(pin: string, staffId: number): Promise<Student[]> {
     const response = await apiCall<{
       status: string;
       data: Student[];
@@ -398,6 +404,7 @@ export const api = {
       headers: {
         Authorization: `Bearer ${DEVICE_API_KEY}`,
         'X-Staff-PIN': pin,
+        'X-Staff-ID': staffId.toString(),
       },
     });
 
@@ -408,7 +415,7 @@ export const api = {
    * Check RFID tag assignment status
    * Endpoint: GET /api/iot/rfid/{tagId}
    */
-  async checkTagAssignment(pin: string, tagId: string): Promise<TagAssignmentCheck> {
+  async checkTagAssignment(pin: string, staffId: number, tagId: string): Promise<TagAssignmentCheck> {
     try {
       const response = await apiCall<{
         status: string;
@@ -418,6 +425,7 @@ export const api = {
         headers: {
           Authorization: `Bearer ${DEVICE_API_KEY}`,
           'X-Staff-PIN': pin,
+          'X-Staff-ID': staffId.toString(),
         },
       });
 
@@ -436,7 +444,7 @@ export const api = {
    * Assign RFID tag to student
    * Endpoint: POST /api/students/{studentId}/rfid
    */
-  async assignTag(pin: string, studentId: number, tagId: string): Promise<TagAssignmentResult> {
+  async assignTag(pin: string, staffId: number, studentId: number, tagId: string): Promise<TagAssignmentResult> {
     const response = await apiCall<{
       status: string;
       data?: {
@@ -451,6 +459,7 @@ export const api = {
       headers: {
         Authorization: `Bearer ${DEVICE_API_KEY}`,
         'X-Staff-PIN': pin,
+        'X-Staff-ID': staffId.toString(),
       },
       body: JSON.stringify({
         rfid_tag: tagId,
@@ -475,7 +484,8 @@ export const api = {
       action: 'checkin' | 'checkout';
       room_id: number;
     },
-    pin: string
+    pin: string,
+    staffId: number
   ): Promise<RfidScanResult> {
     const response = await apiCall<{
       data: RfidScanResult;
@@ -486,6 +496,7 @@ export const api = {
       headers: {
         Authorization: `Bearer ${DEVICE_API_KEY}`,
         'X-Staff-PIN': pin,
+        'X-Staff-ID': staffId.toString(),
       },
       body: JSON.stringify(scanData),
     });
@@ -498,12 +509,13 @@ export const api = {
    * Update session activity to prevent timeout
    * Endpoint: POST /api/iot/session/activity
    */
-  async updateSessionActivity(pin: string): Promise<void> {
+  async updateSessionActivity(pin: string, staffId: number): Promise<void> {
     await apiCall('/api/iot/session/activity', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${DEVICE_API_KEY}`,
         'X-Staff-PIN': pin,
+        'X-Staff-ID': staffId.toString(),
       },
       body: JSON.stringify({
         activity_type: 'rfid_scan', // Changed from 'student_scan' to 'rfid_scan'

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -267,7 +267,7 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
         staffName: authenticatedUser.staffName,
       });
 
-      const rooms = await api.getRooms(authenticatedUser.pin);
+      const rooms = await api.getRooms(authenticatedUser.pin, authenticatedUser.staffId);
 
       storeLogger.debug('Available rooms fetched successfully', { count: rooms.length });
       set({ rooms, isLoading: false });
@@ -301,7 +301,7 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
 
     try {
       storeLogger.info('Fetching current session for device');
-      const session = await api.getCurrentSession(authenticatedUser.pin);
+      const session = await api.getCurrentSession(authenticatedUser.pin, authenticatedUser.staffId);
 
       if (session) {
         storeLogger.info('Active session found', {
@@ -366,7 +366,7 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
           activityId: currentSession.activity_id,
         });
 
-        await api.endSession(authenticatedUser.pin);
+        await api.endSession(authenticatedUser.pin, authenticatedUser.staffId);
         storeLogger.info('Session ended successfully');
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -537,7 +537,7 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
             staffName: authenticatedUser.staffName,
           });
 
-          const activitiesData = await api.getActivities(authenticatedUser.pin);
+          const activitiesData = await api.getActivities(authenticatedUser.pin, authenticatedUser.staffId);
 
           storeLogger.info('Activities loaded successfully', {
             count: activitiesData.length,


### PR DESCRIPTION
## Summary
- Fixed authentication issues where API endpoints were missing the required X-Staff-ID header
- All authenticated endpoints now properly include staff ID validation
- Resolves 401 "missing X-Staff-ID header" errors

## Changes

### API Service Updates
Updated all authenticated API methods to:
- Accept `staffId` as a parameter
- Include `X-Staff-ID` header in requests

Affected endpoints:
- `/api/iot/activities`
- `/api/iot/ping`
- `/api/iot/rooms/available`
- `/api/iot/session/start`
- `/api/iot/session/current` (including getCurrentSessionInfo)
- `/api/iot/session/end`
- `/api/iot/session/activity`
- `/api/iot/students`
- `/api/iot/rfid/{tagId}`
- `/api/students/{studentId}/rfid`
- `/api/iot/checkin`

### Component Updates
- **UserStore**: Pass staffId to all API calls
- **RoomSelectionPage**: Include staffId in session start
- **TagAssignmentPage**: Include staffId in student/tag operations
- **useRfidScanning**: Include staffId in RFID scan and activity updates
- **ActivityScanningPage**: Include staffId in getCurrentSessionInfo calls

## Test plan
- [x] PIN validation works (already confirmed)
- [x] All TypeScript checks pass
- [x] All ESLint checks pass
- [ ] Test session current endpoint
- [ ] Test activities endpoint
- [ ] Test room selection
- [ ] Test RFID scanning
- [ ] Test tag assignment

## Related PRs
- Depends on backend PR that added X-Staff-ID header requirement
- Builds on PR #9 (PIN validation fix)

## Latest Update
Fixed the remaining issue with `getCurrentSessionInfo` method that was missing the X-Staff-ID header, causing 401 errors in the activity scanning page.

🤖 Generated with [Claude Code](https://claude.ai/code)