### PR TITLE
Fix missing X-Staff-ID header in getCurrentSessionInfo

### DIFF
--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -57,7 +57,7 @@ const ActivityScanningPage: React.FC = () => {
     if (!authenticatedUser?.pin) return;
 
     try {
-      const sessionInfo = await api.getCurrentSessionInfo(authenticatedUser.pin);
+      const sessionInfo = await api.getCurrentSessionInfo(authenticatedUser.pin, authenticatedUser.staffId);
       logger.debug('Session info received:', sessionInfo ?? {});
 
       if (sessionInfo) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -529,7 +529,8 @@ export const api = {
    * Endpoint: GET /api/iot/session/current
    */
   async getCurrentSessionInfo(
-    pin: string
+    pin: string,
+    staffId: number
   ): Promise<{ activity_name: string; room_name: string; active_students: number } | null> {
     try {
       const response = await apiCall<{
@@ -540,6 +541,7 @@ export const api = {
         headers: {
           Authorization: `Bearer ${DEVICE_API_KEY}`,
           'X-Staff-PIN': pin,
+          'X-Staff-ID': staffId.toString(),
         },
       });
 


### PR DESCRIPTION
## Summary
Fixed the remaining authentication issue where `getCurrentSessionInfo` was missing the X-Staff-ID header, causing 401 errors in the activity scanning page.

## Problem
After the previous PR #10 was merged, there were still 401 "missing X-Staff-ID header" errors appearing in the logs for the `/api/iot/session/current` endpoint.

## Root Cause
The `getCurrentSessionInfo` method in the API service was missing:
1. The `staffId` parameter
2. The `X-Staff-ID` header in the request

## Changes
- Updated `getCurrentSessionInfo` to accept `staffId` parameter
- Added `X-Staff-ID` header to the session/current endpoint call
- Fixed `ActivityScanningPage` to pass `staffId` when fetching session info

## Testing
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [ ] Verify no more 401 errors in activity scanning page
- [ ] Verify student count updates correctly

## Related Issues
- Builds on PR #10 (already merged)
- Completes the X-Staff-ID header implementation for all endpoints

🤖 Generated with [Claude Code](https://claude.ai/code)