### PR TITLE
Fix student count updates for room transfers

### DIFF
--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -100,8 +100,18 @@ const ActivityScanningPage: React.FC = () => {
         setStudentCount(prev => prev + 1);
       } else if (currentScan.action === 'checked_out') {
         setStudentCount(prev => Math.max(0, prev - 1));
+      } else if (currentScan.action === 'transferred') {
+        // For transfers, check if student is coming to or leaving our room
+        const currentRoomName = selectedRoom?.name;
+        if (currentScan.room_name === currentRoomName) {
+          // Student transferred TO our room from another room
+          setStudentCount(prev => prev + 1);
+        } else if (currentScan.previous_room === currentRoomName) {
+          // Student transferred FROM our room to another room
+          setStudentCount(prev => Math.max(0, prev - 1));
+        }
+        // If neither matches, don't change count (shouldn't happen)
       }
-      // Note: 'transferred' action doesn't change count (checkout + checkin)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentScan, showModal]); // Only update when scan modal shows


### PR DESCRIPTION
## Summary
Fixed the student count not updating correctly when students transfer between rooms in the activity scanning page.

## Problem
When a student was transferred from one room to another, the student count in the continuous scanning page remained unchanged. This was because the transfer action was explicitly ignored in the count update logic.

## Solution
Added logic to handle the 'transferred' action by checking:
- If `room_name` matches current room → student transferred TO our room (count +1)
- If `previous_room` matches current room → student transferred FROM our room (count -1)

## Changes
- Updated `ActivityScanningPage` to properly handle transfer actions
- Uses existing `room_name` and `previous_room` fields from `RfidScanResult`
- Maintains accurate student count across all actions (check-in, check-out, transfer)

## Testing
- [x] TypeScript compilation passes
- [ ] Test student transfers between rooms
- [ ] Verify count increases when student transfers in
- [ ] Verify count decreases when student transfers out
- [ ] Verify regular check-in/out still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)