### PR TITLE
Fix supervisor list refresh on reopen

### DIFF
--- a/src/pages/StaffSelectionPage.tsx
+++ b/src/pages/StaffSelectionPage.tsx
@@ -23,8 +23,8 @@ function StaffSelectionPage() {
   const [currentPage, setCurrentPage] = useState(0);
   const navigate = useNavigate();
 
-  // Create logger instance for this component
-  const logger = createLogger('StaffSelectionPage');
+  // Create stable logger instance for this component
+  const logger = useMemo(() => createLogger('StaffSelectionPage'), []);
 
   // Redirect if missing authentication or selected activity
   useEffect(() => {

--- a/src/pages/TeamManagementPage.tsx
+++ b/src/pages/TeamManagementPage.tsx
@@ -42,8 +42,8 @@ function TeamManagementPage() {
   const orderCounter = useRef(0);
   const navigate = useNavigate();
 
-  // Create logger instance for this component
-  const logger = createLogger('TeamManagementPage');
+  // Create stable logger instance for this component
+  const logger = useMemo(() => createLogger('TeamManagementPage'), []);
 
   // Redirect if not authenticated
   useEffect(() => {
@@ -67,7 +67,8 @@ function TeamManagementPage() {
   useEffect(() => {
     const initializePage = async () => {
       try {
-        await fetchTeachers();
+        // Always refresh to pick up newly added supervisors
+        await fetchTeachers(true);
 
         // If we have an active session and no supervisors selected yet,
         // initialize with current session supervisors

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -179,7 +179,7 @@ interface UserState {
     pin: string;
   }) => void;
   setSelectedActivity: (activity: ActivityResponse) => void;
-  fetchTeachers: () => Promise<void>;
+  fetchTeachers: (forceRefresh?: boolean) => Promise<void>;
   fetchRooms: () => Promise<void>;
   selectRoom: (roomId: number) => void;
   fetchCurrentSession: () => Promise<void>;
@@ -363,24 +363,23 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
 
   setSelectedActivity: (activity: ActivityResponse) => set({ selectedActivity: activity }),
 
-  fetchTeachers: async () => {
+  fetchTeachers: async (forceRefresh = false) => {
     const { isLoading, users } = get();
 
-    // Prevent duplicate requests
-    if (isLoading) {
+    // Prevent unnecessary or duplicate requests unless explicitly forced
+    if (isLoading && !forceRefresh) {
       storeLogger.debug('Teachers fetch already in progress, skipping');
       return;
     }
 
-    // Skip if we already have teachers
-    if (users.length > 0) {
+    if (!forceRefresh && users.length > 0) {
       storeLogger.debug('Teachers already loaded, skipping fetch');
       return;
     }
 
     set({ isLoading: true, error: null });
     try {
-      storeLogger.info('Fetching teachers from API');
+      storeLogger.info('Fetching teachers from API', { forceRefresh });
       const teachers = await api.getTeachers();
       const users = teachers.map(teacherToUser);
 


### PR DESCRIPTION
## Summary
- allow forcing teacher fetch to refresh supervisors
- always refresh teachers when opening team management
- memoize page loggers to prevent re-render fetch loops
