### PR TITLE
Fix back navigation to staff selection from room selection

### DIFF
--- a/src/pages/RoomSelectionPage.tsx
+++ b/src/pages/RoomSelectionPage.tsx
@@ -978,9 +978,9 @@ function RoomSelectionPage() {
 
   // Handle back navigation
   const handleGoBack = () => {
-    logger.info('User navigating back to activity selection');
-    logNavigation('RoomSelectionPage', 'ActivitySelectionPage', { reason: 'back_button' });
-    void navigate('/activity-selection');
+    logger.info('User navigating back to staff selection');
+    logNavigation('RoomSelectionPage', 'StaffSelectionPage', { reason: 'back_button' });
+    void navigate('/staff-selection');
   };
 
   const handleNextPage = () => {


### PR DESCRIPTION
## Summary
- Fixed back button navigation in Room Selection page
- Changed navigation target from Activity Selection to Staff Selection
- Updated logging to reflect correct navigation flow

## Changes
- `src/pages/RoomSelectionPage.tsx:978-983` - Updated `handleGoBack()` to navigate to `/staff-selection` instead of `/activity-selection`

## Test Plan
- [x] Code quality checks pass (ESLint + TypeScript)
- [ ] Manual testing: Navigate to Room Selection page and verify back button goes to Staff Selection
- [ ] Verify log messages show correct navigation path