### PR TITLE
Fix #52: Improve error messages in Home Setup Phase

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -18,7 +18,7 @@ interface ApiConfig {
  * Map server error messages to German user-friendly messages
  * This enables better debugging by distinguishing different error types
  */
-function mapServerErrorToGerman(errorMessage: string): string {
+export function mapServerErrorToGerman(errorMessage: string): string {
   // API-Key Fehler
   if (errorMessage.includes('invalid device API key')) {
     return 'API-Schlüssel ungültig. Bitte Geräte-Konfiguration prüfen.';

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import type { NetworkStatusData } from '../components/ui/NetworkStatus';
 import {
   api,
+  mapServerErrorToGerman,
   type Teacher,
   type ActivityResponse,
   type Room,
@@ -389,7 +390,7 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       storeLogger.error('Failed to fetch teachers', { error: errorMessage });
       set({
-        error: 'Fehler beim Laden der Lehrer. Bitte versuchen Sie es erneut.',
+        error: mapServerErrorToGerman(errorMessage),
         isLoading: false,
       });
       throw error;
@@ -400,8 +401,9 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
     const { authenticatedUser } = get();
 
     if (!authenticatedUser?.pin) {
+      const errorMsg = 'Keine Authentifizierung für das Laden von Räumen';
       storeLogger.warn('Cannot fetch rooms: no authenticated user or PIN');
-      set({ error: 'Keine Authentifizierung für das Laden von Räumen', isLoading: false });
+      set({ error: mapServerErrorToGerman(errorMsg), isLoading: false });
       return;
     }
 
@@ -419,7 +421,7 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Fehler beim Laden der Räume';
       storeLogger.error('Failed to fetch available rooms', { error: errorMessage });
-      set({ error: errorMessage, isLoading: false });
+      set({ error: mapServerErrorToGerman(errorMessage), isLoading: false });
     }
   },
 
@@ -743,16 +745,18 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
       set({ isLoading: true, error: null });
 
       if (!authenticatedUser) {
+        const errorMsg = 'Keine Authentifizierung für das Laden von Aktivitäten';
         set({
-          error: 'Keine Authentifizierung für das Laden von Aktivitäten',
+          error: mapServerErrorToGerman(errorMsg),
           isLoading: false,
         });
         return null;
       }
 
       if (!authenticatedUser.pin) {
+        const errorMsg = 'PIN nicht verfügbar. Bitte loggen Sie sich erneut ein.';
         set({
-          error: 'PIN nicht verfügbar. Bitte loggen Sie sich erneut ein.',
+          error: mapServerErrorToGerman(errorMsg),
           isLoading: false,
         });
         return null;
@@ -788,7 +792,7 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
           });
 
           set({
-            error: 'Fehler beim Laden der Aktivitäten',
+            error: mapServerErrorToGerman(errorMessage),
             isLoading: false,
           });
 


### PR DESCRIPTION
## Summary

Implements improved error messages for the Home Setup Phase by applying `mapServerErrorToGerman()` to all error paths, as requested in issue #52.

## Changes

### Modified Files
- **src/services/api.ts**: Exported `mapServerErrorToGerman()` for reuse in store
- **src/store/userStore.ts**: Applied error mapping to 6 error paths

### Error Paths Updated

| Location | Function | Context |
|----------|----------|---------|
| Line 393 | `fetchTeachers` | API error handling |
| Line 406 | `fetchRooms` | Auth validation (missing PIN) |
| Line 424 | `fetchRooms` | API error handling |
| Line 750 | `fetchActivities` | Auth validation (missing user) |
| Line 759 | `fetchActivities` | Auth validation (missing PIN) |
| Line 795 | `fetchActivities` | API error handling |

## Error Message Improvements

Users now see specific error messages that distinguish between:
- ✅ API-Key errors ("API-Schlüssel ungültig...")
- ✅ Network errors ("Keine Netzwerkverbindung...")
- ✅ Server errors ("Server nicht erreichbar...")
- ✅ PIN errors ("Ungültiger PIN...")
- ✅ Account locked errors ("Konto gesperrt...")

## Testing

- ✅ ESLint: 0 errors
- ✅ TypeScript: 0 errors
- ✅ Prettier: All files formatted

## Related

- Closes #52
- Follows pattern from PR #51 (#39)