### PR TITLE
Fix #55: Improve error messages for attendance and feedback workflow

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -65,7 +65,11 @@ function isNetworkErrorMessage(errorMessage: string): boolean {
     lowerMessage.includes('verbindung') ||
     lowerMessage.includes('fetch') ||
     lowerMessage.includes('networkerror') ||
-    lowerMessage.includes('network')
+    lowerMessage.includes('network') ||
+    lowerMessage.includes('timeout') ||
+    lowerMessage.includes('timed out') ||
+    lowerMessage.includes('connection') ||
+    lowerMessage.includes('offline')
   );
 }
 
@@ -116,16 +120,7 @@ export function mapAttendanceErrorToGerman(
     return 'Ungültige Anfrage. Bitte Eingaben prüfen.';
   }
 
-  // Server errors
-  if (
-    errorMessage.includes('500') ||
-    errorMessage.includes('502') ||
-    errorMessage.includes('503')
-  ) {
-    return 'Server nicht erreichbar. Bitte später versuchen.';
-  }
-
-  // Fallback - use generic mapper
+  // Fallback - use generic mapper (handles 5xx errors and other cases)
   return mapServerErrorToGerman(errorMessage);
 }
 


### PR DESCRIPTION
## Summary
- Add `mapAttendanceErrorToGerman()` function for context-aware error messages in attendance/feedback operations
- Replace static error strings with dynamic, context-specific messages
- Handle network errors, 401, 400, 403, 404, and 5xx errors appropriately

## Changes
| Method | Error | Old Message | New Message |
|--------|-------|-------------|-------------|
| `getAttendanceStatus` | 404 | "Schüler nicht gefunden oder keine Anwesenheitsdaten verfügbar" | "Schüler nicht gefunden oder keine Anwesenheitsdaten für heute verfügbar." |
| `getAttendanceStatus` | 403 | "Keine Berechtigung für diesen Schüler" | "Keine Berechtigung für Anwesenheitsstatus dieses Schülers." |
| `toggleAttendance` | 404 | "Schüler nicht gefunden" | "Schüler nicht gefunden. RFID-Tag möglicherweise nicht zugewiesen." |
| `toggleAttendance` | 403 | "Keine Berechtigung für diesen Schüler" | "Keine Berechtigung für An-/Abmeldung dieses Schülers." |
| `submitDailyFeedback` | 404 | "Feedback-Service nicht verfügbar" | "Feedback-Service nicht erreichbar. Bitte später versuchen." |
| `submitDailyFeedback` | 403 | "Keine Berechtigung für Feedback-Übermittlung" | (unchanged) |

## Test plan
- [ ] Verify `npm run check` passes (ESLint + TypeScript)
- [ ] Test attendance status lookup with invalid RFID
- [ ] Test toggle attendance with permission error
- [ ] Test feedback submission with service unavailable

Closes #55