### PR TITLE
Fix #56: Add user-facing notifications for RFID and session errors

### DIFF
--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -68,6 +68,25 @@ export const useRfidScanning = () => {
   const isServiceStartedRef = useRef<boolean>(false);
   const scannedSupervisorsRef = useRef<Set<number>>(new Set());
 
+  // Helper to show system error modal
+  const showSystemError = useCallback(
+    (title: string, message: string) => {
+      const errorResult: ExtendedRfidScanResult = {
+        student_name: title,
+        student_id: 0,
+        action: 'error',
+        message,
+        showAsError: true,
+      };
+      setScanResult(errorResult as RfidScanResult);
+      showScanModal();
+      setTimeout(() => {
+        hideScanModal();
+      }, rfid.modalDisplayTime);
+    },
+    [setScanResult, showScanModal, hideScanModal, rfid.modalDisplayTime]
+  );
+
   // Initialize RFID service on mount
   const initializeService = useCallback(async () => {
     if (!isRfidEnabled() || isInitializedRef.current) {
@@ -80,13 +99,22 @@ export const useRfidScanning = () => {
       logger.info('RFID service initialized');
     } catch (error) {
       logger.error('Failed to initialize RFID service', { error });
+      showSystemError(
+        'RFID-Initialisierung fehlgeschlagen',
+        'Das RFID-Lesegerät konnte nicht initialisiert werden. Bitte Gerät neu starten.'
+      );
     }
-  }, []);
+  }, [showSystemError]);
 
   const processScan = useCallback(
     async (tagId: string) => {
       if (!authenticatedUser?.pin || !selectedRoom) {
         logger.error('Missing authentication or room selection');
+        showSystemError('Sitzung abgelaufen', 'Bitte melden Sie sich erneut an.');
+        // Navigate to home after showing error
+        setTimeout(() => {
+          void navigate('/home');
+        }, rfid.modalDisplayTime);
         return;
       }
 
@@ -463,6 +491,7 @@ export const useRfidScanning = () => {
       rfid.modalDisplayTime,
       rfid.recentTagScans,
       navigate,
+      showSystemError,
     ]
   );
 
@@ -495,8 +524,12 @@ export const useRfidScanning = () => {
       logger.info('RFID event listener setup complete');
     } catch (error) {
       logger.error('Failed to setup RFID event listener', { error });
+      showSystemError(
+        'RFID-Verbindung fehlgeschlagen',
+        'Das RFID-System konnte nicht verbunden werden. Scannen nicht möglich.'
+      );
     }
-  }, [isTagBlocked, processScan]);
+  }, [isTagBlocked, processScan, showSystemError]);
 
   const startScanning = useCallback(async () => {
     const callTimestamp = Date.now();
@@ -579,8 +612,12 @@ export const useRfidScanning = () => {
         timestamp: Date.now(),
         timeSinceCall: Date.now() - callTimestamp,
       });
+      showSystemError(
+        'RFID-Service Start fehlgeschlagen',
+        'Das RFID-Lesegerät konnte nicht gestartet werden. Bitte Gerät prüfen.'
+      );
     }
-  }, [startRfidScanning, isTagBlocked, processScan]);
+  }, [startRfidScanning, isTagBlocked, processScan, showSystemError]);
 
   const stopScanning = useCallback(async () => {
     const callTimestamp = Date.now();


### PR DESCRIPTION
## Summary
- Add user-facing error notifications for previously logged-only errors
- RFID initialization, service start, and event listener failures now show German error modals
- Session expiration during scanning now shows modal and navigates to home
- Attendance toggle failures show network-aware error messages
- Schulhof room configuration errors now display user-friendly messages

## Changes
| Error | User Message |
|-------|--------------|
| RFID Init Failed | "RFID-Initialisierung fehlgeschlagen" |
| Session Lost | "Sitzung abgelaufen" + navigation to /home |
| Event Listener Failed | "RFID-Verbindung fehlgeschlagen" |
| RFID Service Start Failed | "RFID-Service Start fehlgeschlagen" |
| Toggle Attendance Failed | "Abmeldung fehlgeschlagen" + network-aware detail |
| Schulhof Room Missing | "Schulhof nicht verfügbar" |

## Files Changed
- `src/hooks/useRfidScanning.ts` - Added `showSystemError` helper and error notifications
- `src/pages/ActivityScanningPage.tsx` - Added error modals for attendance and Schulhof errors

## Test Plan
- [ ] Verify RFID init error shows modal (simulate by disconnecting RFID reader on Pi)
- [ ] Verify session expiration shows modal and navigates home
- [ ] Verify attendance toggle error shows modal with student name
- [ ] Verify Schulhof error shows modal when room not configured
- [ ] Run `npm run check` - passes with 0 errors/warnings

Closes #56