### PR TITLE
Fix #56: Add user-facing notifications for RFID and session errors

### DIFF
--- a/src/services/studentCache.ts
+++ b/src/services/studentCache.ts
@@ -231,6 +231,7 @@ export function setCachedStudent(
 
 /**
  * Convert API scan result to cached student format
+ * Returns null if student_id is null (e.g., error states, supervisor scans)
  */
 export function scanResultToCachedStudent(
   scanResult: RfidScanResult,
@@ -238,7 +239,12 @@ export function scanResultToCachedStudent(
     room?: string;
     activity?: string;
   }
-): Omit<CachedStudent, 'cachedAt'> {
+): Omit<CachedStudent, 'cachedAt'> | null {
+  // Cannot cache results without a valid student ID
+  if (scanResult.student_id === null) {
+    return null;
+  }
+
   return {
     id: scanResult.student_id,
     name: scanResult.student_name,


### PR DESCRIPTION
## Summary
- Add user-facing error notifications for previously logged-only errors
- RFID initialization, service start, and event listener failures now show German error modals
- Session expiration during scanning now shows modal and navigates to home
- Attendance toggle failures show network-aware error messages
- Schulhof room configuration errors now display user-friendly messages

## PR Review Fixes (commit 289cd50)
- Fix unsafe type cast: extend RfidScanResult with `error`/`already_in` actions
- Change `student_id` to `number | null` for proper error state representation
- Consolidate network error detection into single `isNetworkRelatedError` function
- Add background sync failure notification to users
- Replace native `alert()` with `ErrorModal` in RoomSelectionPage
- Add null guards throughout for student_id handling

## Changes
| Error | User Message |
|-------|--------------|
| RFID Init Failed | "RFID-Initialisierung fehlgeschlagen" |
| Session Lost | "Sitzung abgelaufen" + navigation to /home |
| Event Listener Failed | "RFID-Verbindung fehlgeschlagen" |
| RFID Service Start Failed | "RFID-Service Start fehlgeschlagen" |
| Toggle Attendance Failed | "Abmeldung fehlgeschlagen" + network-aware detail |
| Schulhof Room Missing | "Schulhof nicht verfügbar" |
| Background Sync Failed | "Sync ausstehend" notification |

## Files Changed
- `src/hooks/useRfidScanning.ts` - Error notifications + sync warning
- `src/pages/ActivityScanningPage.tsx` - Error modals for attendance/Schulhof
- `src/pages/RoomSelectionPage.tsx` - ErrorModal instead of alert()
- `src/services/api.ts` - Extended RfidScanResult type, consolidated isNetworkRelatedError
- `src/services/studentCache.ts` - Handle null student_id
- `src/store/userStore.ts` - Re-export isNetworkRelatedError, null handling

## Test Plan
- [ ] Verify RFID init error shows modal
- [ ] Verify session expiration shows modal and navigates home
- [ ] Verify attendance toggle error shows modal with student name
- [ ] Verify Schulhof error shows modal when room not configured
- [ ] Verify background sync failure shows "Sync ausstehend" notification
- [ ] Run `npm run check` - passes with 0 errors/warnings

Closes #56