### PR TITLE
fix(ui): remove dead conditional returning same value in both branches

### DIFF
--- a/src/components/LastSessionToggle.tsx
+++ b/src/components/LastSessionToggle.tsx
@@ -88,8 +88,7 @@ export const LastSessionToggle: React.FC = () => {
                 backgroundColor: '#FFFFFF',
                 borderRadius: '50%',
                 boxShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
-                transition: 'transform 200ms ease-out',
-                transform: `translateX(${isEnabled ? '0' : '0'})`,
+                transition: 'left 200ms ease-out',
               }}
             />
             {isEnabled && (


### PR DESCRIPTION
## Summary
- Remove useless ternary `translateX(${isEnabled ? '0' : '0'})` in `LastSessionToggle.tsx` that always returns the same value regardless of condition
- Fix transition property to target `left` instead of `transform` (since `left` is what actually animates the toggle knob)

## SonarCloud Issue
- **Rule**: S3923 - All branches in a conditional structure should not have exactly the same implementation
- **Type**: BUG (Reliability)
- **Impact**: This was the only open bug, causing Reliability rating to show C instead of A

## Test plan
- [x] `npm run check` passes (ESLint + TypeScript)
- [x] Toggle animation still works correctly in dev mode
- [ ] SonarCloud scan shows no S3923 violations after merge

Fixes #172