### PR TITLE
fix: resolve race condition in daily checkout modal

### DIFF
--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -390,7 +390,9 @@ export const useRfidScanning = () => {
         });
 
         updateOptimisticScan(scanId, 'success');
-        setScanResult(result);
+        // Include scannedTagId so ActivityScanningPage can use it directly
+        // instead of looking it up from recentTagScans (fixes race condition)
+        setScanResult({ ...result, scannedTagId: tagId });
 
         // Handle supervisor authentication (returns true if handled)
         const supervisorHandled = await handleSupervisorAuthentication({

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1278,6 +1278,8 @@ export interface RfidScanResult {
   showAsError?: boolean;
   /** Indicates this result is informational (not a scan result) */
   isInfo?: boolean;
+  /** The RFID tag that was scanned (added by frontend, not from server) */
+  scannedTagId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes a race condition where the daily checkout modal displayed with incorrect styling (orange background instead of blue)
- Root cause: `recentTagScans` wasn't populated when `ActivityScanningPage` useEffect ran after `setScanResult()`
- Solution: Include `scannedTagId` directly in the scan result to avoid lookup timing issues

## Root Cause Analysis
The bug was introduced by today's refactoring (commits 4c4ee3f and 66619a2). The timing issue:

1. `setScanResult(result)` triggered the ActivityScanningPage useEffect
2. The useEffect called `findTagForStudent()` which searched `recentTagScans`
3. But `recordTagScan()` ran AFTER `setScanResult()`, so `recentTagScans` was empty
4. Result: `dailyCheckoutState.rfid` was set to empty string
5. Later, when `recentTagScans` updated, the "clear stale state" logic detected a mismatch and cleared `dailyCheckoutState`

## Changes
- **useRfidScanning.ts**: Add `scannedTagId: tagId` to the result passed to `setScanResult()`
- **api.ts**: Add `scannedTagId?: string` to `RfidScanResult` interface
- **ActivityScanningPage.tsx**: 
  - Use `scan.scannedTagId` directly instead of `findTagForStudent()` lookup
  - Remove unused `findTagForStudent` and `TagScanEntry`

## Test plan
- [ ] Check in a student - verify green modal appears
- [ ] During daily checkout time, check out a student - verify **blue** modal with "Gehst du nach Hause?" and Yes/No buttons
- [ ] Click "Ja, nach Hause" - verify feedback prompt appears
- [ ] Regular checkout (not daily checkout time) - verify orange modal with destination selection