### PR TITLE
fix(security): address SonarCloud security hotspots #173

### DIFF
--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { api, mapApiErrorToGerman, ApiError } from '../services/api';
 import type { RfidScanResult, CurrentSession } from '../services/api';
 import { useUserStore } from '../store/userStore';
+import { getSecureRandomInt } from '../utils/crypto';
 import { createLogger } from '../utils/logger';
 import { safeInvoke, isRfidEnabled } from '../utils/tauriContext';
 
@@ -48,11 +49,9 @@ const createOptimisticScan = (scanId: string, tagId: string) => ({
 
 /**
  * Generates a unique scan ID for tracking optimistic updates.
- * Note: Math.random() is intentionally used here as this ID is only for UI tracking,
- * not for security purposes. Cryptographic randomness is not required.
+ * Uses crypto.randomUUID() for cryptographically secure random values.
  */
-const generateScanId = (): string =>
-  `scan_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`; // NOSONAR - not used for security
+const generateScanId = (): string => `scan_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
 
 /**
  * Handles supervisor authentication from RFID scan.
@@ -541,8 +540,9 @@ export const useRfidScanning = () => {
                   '04:11:22:33:44:55:66',
                 ];
 
-            // Pick a random tag from the list
-            const mockTagId = mockStudentTags[Math.floor(Math.random() * mockStudentTags.length)];
+            // Pick a random tag from the list using unbiased secure randomness
+            const randomIndex = getSecureRandomInt(mockStudentTags.length);
+            const mockTagId = mockStudentTags[randomIndex];
 
             logger.info('Mock RFID scan generated', {
               tagId: mockTagId,
@@ -556,7 +556,7 @@ export const useRfidScanning = () => {
               void processScan(mockTagId);
             }
           },
-          5000 + Math.random() * 5000
+          5000 + getSecureRandomInt(5000)
         ); // Random interval between 5-10 seconds
 
         isServiceStartedRef.current = true;

--- a/src/pages/TagAssignmentPage.tsx
+++ b/src/pages/TagAssignmentPage.tsx
@@ -10,6 +10,7 @@ import { api, type TagAssignmentCheck } from '../services/api';
 import { useUserStore } from '../store/userStore';
 import { designSystem } from '../styles/designSystem';
 import theme from '../styles/theme';
+import { getSecureRandomInt } from '../utils/crypto';
 import { logNavigation, logUserAction, logError, createLogger } from '../utils/logger';
 import { safeInvoke, isTauriContext, isRfidEnabled } from '../utils/tauriContext';
 
@@ -175,8 +176,9 @@ function TagAssignmentPage() {
                 '04:11:22:33:44:55:66',
               ];
 
-          // Pick a random tag from the list
-          const mockTagId = mockStudentTags[Math.floor(Math.random() * mockStudentTags.length)];
+          // Pick a random tag from the list using unbiased secure randomness
+          const randomIndex = getSecureRandomInt(mockStudentTags.length);
+          const mockTagId = mockStudentTags[randomIndex];
           logUserAction('Mock RFID tag scanned', { tagId: mockTagId, platform: 'Development' });
           void handleTagScanned(mockTagId);
         }, 2000);

--- a/src/services/syncQueue.ts
+++ b/src/services/syncQueue.ts
@@ -45,7 +45,7 @@ export function queueFailedScan(
   roomId: number,
   pin: string
 ): string {
-  const operationId = `sync_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+  const operationId = `sync_${Date.now()}_${crypto.randomUUID().slice(0, 8)}`;
 
   const queuedScan: QueuedScan = {
     id: operationId,

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -18,6 +18,7 @@ import {
   loadSessionSettings,
   clearLastSession,
 } from '../services/sessionStorage';
+import { getSecureRandomInt } from '../utils/crypto';
 import { createLogger, LogLevel } from '../utils/logger';
 import { loggerMiddleware } from '../utils/storeMiddleware';
 
@@ -563,9 +564,9 @@ const RFID_SESSION_INITIAL_STATE = {
   optimisticScans: [] as OptimisticScanState[],
 };
 
-// Generate a unique id for new activities
+// Generate a unique id for new activities using unbiased secure randomness
 const generateId = (): number => {
-  return Math.floor(Math.random() * 10000);
+  return getSecureRandomInt(10000);
 };
 
 // Create mock student data

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,41 @@
+/**
+ * Cryptographically Secure Random Utilities
+ *
+ * These utilities use the Web Crypto API to generate cryptographically secure
+ * random values without modulo bias.
+ */
+
+/**
+ * Returns a uniformly distributed integer in [0, maxExclusive) using rejection sampling.
+ * This avoids modulo bias when mapping crypto.getRandomValues() to a smaller range.
+ *
+ * @param maxExclusive - The exclusive upper bound (must be a positive integer)
+ * @returns A random integer in [0, maxExclusive)
+ * @throws Error if maxExclusive is not a positive integer
+ *
+ * @example
+ * // Get a random index for an array
+ * const index = getSecureRandomInt(array.length);
+ *
+ * @example
+ * // Get a random delay between 0-4999ms
+ * const delay = getSecureRandomInt(5000);
+ */
+export const getSecureRandomInt = (maxExclusive: number): number => {
+  if (maxExclusive <= 0 || !Number.isInteger(maxExclusive)) {
+    throw new Error('maxExclusive must be a positive integer');
+  }
+
+  const maxUint32 = 0x100000000; // 2^32
+  const limit = Math.floor(maxUint32 / maxExclusive) * maxExclusive;
+  const randomValues = new Uint32Array(1);
+
+  // Rejection sampling: discard values that would cause bias
+  let value: number;
+  do {
+    crypto.getRandomValues(randomValues);
+    value = randomValues[0];
+  } while (value >= limit);
+
+  return value % maxExclusive;
+};

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -281,7 +281,7 @@ export class Logger {
    * @returns Session ID string
    */
   private generateSessionId(): string {
-    return Date.now().toString(36) + Math.random().toString(36).substring(2);
+    return `${Date.now().toString(36)}_${crypto.randomUUID().slice(0, 8)}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace all `Math.random()` usages with cryptographically secure alternatives
- Addresses 6 SonarCloud S2245 security hotspots (weak PRNG usage)

## Changes
| File | Change |
|------|--------|
| `syncQueue.ts` | Use `crypto.randomUUID()` for operation IDs |
| `logger.ts` | Use `crypto.randomUUID()` for session IDs |
| `useRfidScanning.ts` | Use `crypto.randomUUID()` for scan IDs, `crypto.getRandomValues()` for mock tag selection |
| `userStore.ts` | Use `crypto.getRandomValues()` for mock activity IDs |
| `TagAssignmentPage.tsx` | Use `crypto.getRandomValues()` for mock tag selection |

## Why crypto APIs?
SonarCloud rule S2245 flags `Math.random()` because it uses a weak PRNG. While none of these usages were security-sensitive, using `crypto.randomUUID()` and `crypto.getRandomValues()` satisfies the security scanner and follows best practices.

## Test plan
- [x] `npm run check` passes (ESLint + TypeScript)
- [x] Code formatted with Prettier
- [ ] SonarCloud security hotspots should be resolved after merge

Closes #173