### PR TITLE
fix(quality): use stable identifiers instead of array index for keys

### DIFF
--- a/src/pages/PinPage.tsx
+++ b/src/pages/PinPage.tsx
@@ -84,8 +84,9 @@ function PinPage() {
     };
   }, [logger]);
 
-  // Maximum PIN length
+  // Maximum PIN length and stable dot identifiers for React keys
   const maxPinLength = 4;
+  const pinDotIds = ['dot-1', 'dot-2', 'dot-3', 'dot-4'] as const;
 
   // Auto-submit when PIN is complete
   useEffect(() => {
@@ -311,9 +312,9 @@ function PinPage() {
                 margin: '0 auto 12px auto',
               }}
             >
-              {Array.from({ length: maxPinLength }).map((_, i) => (
+              {pinDotIds.map((dotId, i) => (
                 <div
-                  key={`pin-dot-${i}`}
+                  key={dotId}
                   style={{
                     width: '24px',
                     height: '24px',


### PR DESCRIPTION
## Summary
- Replace array index-based React keys with stable string identifiers in `PinPage.tsx`
- Addresses SonarCloud react/no-array-index-key rule

## Changes
```diff
- {Array.from({ length: maxPinLength }).map((_, i) => (
-   <div key={`pin-dot-${i}`} ...>
+ const pinDotIds = ['dot-1', 'dot-2', 'dot-3', 'dot-4'] as const;
+ ...
+ {pinDotIds.map((dotId, i) => (
+   <div key={dotId} ...>
```

## Why This Matters
While array indices are technically safe for static lists that never reorder, SonarCloud flags them as a potential issue. Using explicit stable identifiers:
- Satisfies the linter rule
- Makes the code more explicit about the fixed nature of the list
- No runtime behavior change

## Test Plan
- [x] `npm run check` passes (ESLint + TypeScript)
- [x] PIN dot display unchanged (4 dots, same styling)

Resolves part of #169