### PR TITLE
fix(quality): reduce cognitive complexity via hook extraction and refactoring

### DIFF
--- a/src/hooks/useEntityFetching.ts
+++ b/src/hooks/useEntityFetching.ts
@@ -1,0 +1,107 @@
+/**
+ * Custom hook for fetching and managing assignable entities (students and teachers)
+ * Extracted from StudentSelectionPage to reduce cognitive complexity
+ */
+import { useState, useEffect, useMemo } from 'react';
+
+import { api, type Student, type Teacher } from '../services/api';
+import { createLogger } from '../utils/logger';
+
+// Union type for assignable entities
+export type AssignableEntity =
+  | { type: 'student'; data: Student }
+  | { type: 'teacher'; data: Teacher };
+
+interface UseEntityFetchingParams {
+  pin: string | undefined;
+  staffId: number | undefined;
+  supervisorIds: number[];
+  isAuthenticated: boolean;
+}
+
+interface UseEntityFetchingResult {
+  entities: AssignableEntity[];
+  isLoading: boolean;
+  error: string | null;
+  availableClasses: string[];
+}
+
+const logger = createLogger('useEntityFetching');
+
+/**
+ * Hook that fetches students and teachers, combining them into a unified entity list
+ */
+export function useEntityFetching({
+  pin,
+  staffId,
+  supervisorIds,
+  isAuthenticated,
+}: UseEntityFetchingParams): UseEntityFetchingResult {
+  const [entities, setEntities] = useState<AssignableEntity[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchEntities = async () => {
+      if (!pin) return;
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        logger.debug('Fetching students and teachers', {
+          supervisorCount: supervisorIds.length,
+          authenticatedUserId: staffId,
+        });
+
+        // If no supervisors selected, use authenticated user's ID
+        const teacherIds = supervisorIds.length > 0 ? supervisorIds : [staffId!];
+
+        // Fetch both students and teachers in parallel
+        const [studentList, teacherList] = await Promise.all([
+          api.getStudents(pin, teacherIds),
+          api.getTeachers(),
+        ]);
+
+        // Combine into unified entity list
+        const combinedEntities: AssignableEntity[] = [
+          ...studentList.map(s => ({ type: 'student' as const, data: s })),
+          ...teacherList.map(t => ({ type: 'teacher' as const, data: t })),
+        ];
+
+        setEntities(combinedEntities);
+        logger.info('Entities fetched successfully', {
+          students: studentList.length,
+          teachers: teacherList.length,
+          total: combinedEntities.length,
+        });
+      } catch (err) {
+        const errorObj = err instanceof Error ? err : new Error(String(err));
+        logger.error('Failed to fetch entities', {
+          error: errorObj.message,
+          stack: errorObj.stack,
+        });
+        setError(`Fehler beim Laden: ${errorObj.message}`);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (isAuthenticated) {
+      void fetchEntities();
+    }
+  }, [pin, staffId, supervisorIds, isAuthenticated]);
+
+  // Extract available classes from student entities
+  const availableClasses = useMemo(() => {
+    const classSet = new Set<string>();
+    for (const entity of entities) {
+      if (entity.type === 'student' && entity.data.school_class) {
+        classSet.add(entity.data.school_class);
+      }
+    }
+    return Array.from(classSet).sort((a, b) => a.localeCompare(b, 'de'));
+  }, [entities]);
+
+  return { entities, isLoading, error, availableClasses };
+}


### PR DESCRIPTION
## Summary
Address remaining SonarCloud S3776 cognitive complexity issues (21 → ≤15) by extracting complex logic into custom hooks and pure helper functions.

## Previous Attempt
PR #201 extracted some helper functions but did not reduce the **component-level** complexity because the helpers were inside the component scope. SonarCloud measures complexity of the entire function including all nested functions.

## This Fix

### StudentSelectionPage.tsx
Created new `useEntityFetching` hook that encapsulates:
- Entity fetching logic (students + teachers)
- Loading and error state management
- Available classes computation

**Before:** 95 lines of fetch logic inside component
**After:** Hook returns `{ entities, isLoading, error, availableClasses }`

### HomeViewPage.tsx
Extracted pure functions **outside** the component:
| Function | Purpose |
|----------|---------|
| `validateSessionRecreationData()` | Validates session data, returns result object |
| `executeSessionRecreation()` | Executes API call, returns success/error result |

**Before:** `handleConfirmRecreation` with try/catch nesting
**After:** Sequential early-return pattern using helper results

## Why This Works
SonarCloud's cognitive complexity counts:
- Each `if`, `else`, `for`, `while`, `catch` (+1)
- Nesting depth multiplier (+1 per level)
- Logical operators in conditions

By moving logic **outside** the component function:
- The component's measured complexity decreases
- The extracted functions have their own (lower) complexity scores
- Total code complexity is the same, but distributed appropriately

## Test Plan
- [x] `npm run check` passes (ESLint + TypeScript)
- [x] No behavioral changes (pure refactoring)
- [x] Entity fetching still works (hook encapsulates same logic)
- [x] Session recreation still works (same validation + API calls)

Resolves #169