### PR TITLE
ci: add knip dead code check to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,3 +20,6 @@ jobs:
         
       - name: Check formatting
         run: npm run format:check
+
+      - name: Check for dead code
+        run: npm run knip


### PR DESCRIPTION
## Summary
- Add knip as a blocking CI check in the lint workflow
- Prevents dead code (unused exports, files, dependencies) from accumulating
- Runs on PRs to main/development and pushes to development

## Why
We just cleaned up dead code in PR #206. This ensures it doesn't accumulate again.

## Notes
- Knip is already configured in `package.json` with proper entry points and ignores
- Added to `lint.yml` only (not `code-quality.yml`) to avoid duplicate runs on PRs