### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @yungweng


### PR DESCRIPTION
## Summary
Add CODEOWNERS file to enable code owner reviews.

## Changes
- `* @yungweng` - All files owned by @yungweng

## Why
Branch protection now requires code owner reviews (`require_code_owner_reviews: true`).
This allows the repo owner to approve their own PRs without needing external reviewers.