### PR TITLE
docs: rewrite README with accurate info and clearer language

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024-2025 MOTO
+Copyright (c) 2024-2026 MOTO
 
 SOURCE-AVAILABLE LICENSE
 


### PR DESCRIPTION
## Summary

- Rewrote the entire README: fixed 16 factual errors, replaced stale content, applied Orwell's writing rules for clarity
- Updated copyright year from 2024-2025 to 2024-2026 in both README and LICENSE

### Errors fixed

| # | What was wrong |
|---|---|
| 1 | React badge said 18.3.1 (actually 19) |
| 2 | TypeScript said 5.6.2 (actually 5.9) |
| 3 | Zustand said 5.0.4 (actually 5) |
| 4 | React Router said 7.6.0 (actually 7) |
| 5 | TailwindCSS said 4.1.6 (actually 4) |
| 6 | Vite said 6.0.3 (actually 7) |
| 7 | License claimed MIT (actually Source-Available) |
| 8 | Linked nonexistent CONTRIBUTING.md |
| 9 | Clone URL had `yourusername` placeholder |
| 10 | "Cross-Platform" claim was misleading (RFID is Pi-only) |
| 11 | "In Development" listed already-shipped features |
| 12 | API table had fake endpoints |
| 13 | "Uses mock data" note (real API exists) |
| 14 | Auth flow described a nonexistent session token |
| 15 | "Future Dev" listed RFID as planned (already built) |
| 16 | Copyright year was 2025, now 2026 |

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all image paths still resolve
- [ ] Check Mermaid diagram renders in GitHub markdown