### PR TITLE
fix: add retry logic to initial network check for Pi boot

### DIFF
--- a/src/hooks/useNetworkStatus.ts
+++ b/src/hooks/useNetworkStatus.ts
@@ -119,6 +119,11 @@ export const useNetworkStatus = () => {
     isCheckingRef.current = true;
 
     try {
+      // Intentionally keep default "online" state during retries rather than updating
+      // on each failure. The Pi boot race condition means WiFi is often just slow to
+      // initialize (not actually down), so we avoid showing a false "offline" status
+      // that would alarm users during normal startup. If truly offline, state updates
+      // after all retries exhaust (~3s).
       for (let attempt = 1; attempt <= INITIAL_CHECK_MAX_RETRIES; attempt++) {
         const status = await checkNetworkStatus();
 


### PR DESCRIPTION
## Summary

- Add retry logic (3 attempts, 1s delay) to the initial network check on startup
- Fixes false "wifi disconnected" icon when network isn't ready during Pi boot
- Periodic checks remain unchanged (no retries)

## Test plan

- [x] `npm run check` passes
- [x] `npm run tauri dev` - normal startup works
- [ ] Test on Pi with slow/delayed network at boot
- [ ] Check logs for retry messages