### PR TITLE
fix(api): comprehensive backend error message mapping

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -81,9 +81,13 @@ type ErrorMapping = readonly [pattern: string | readonly string[], germanMessage
  */
 const ERROR_MESSAGE_MAPPINGS: readonly ErrorMapping[] = [
   // 1. CAPACITY ERRORS (409)
-  ['ACTIVITY_CAPACITY_EXCEEDED', 'Aktivität ist voll. Maximale Teilnehmerzahl erreicht.'],
+  // Backend sends both lowercase (Go errors) and capitalized (JSON Message field)
   [
-    ['ROOM_CAPACITY_EXCEEDED', 'Room capacity exceeded'],
+    ['ACTIVITY_CAPACITY_EXCEEDED', 'activity capacity exceeded', 'Activity capacity exceeded'],
+    'Aktivität ist voll. Maximale Teilnehmerzahl erreicht.',
+  ],
+  [
+    ['ROOM_CAPACITY_EXCEEDED', 'room capacity exceeded', 'Room capacity exceeded'],
     'Raum ist voll. Kein Platz mehr verfügbar.',
   ],
 


### PR DESCRIPTION
## Summary

- Extended `mapServerErrorToGerman()` with **48 specific backend error messages**
- Prevents misleading error displays by matching exact backend messages before generic HTTP status codes
- All error messages verified against actual backend source code

## Problem

When the API base URL was incorrect or other non-RFID errors occurred, users saw misleading messages. For example:
- Any 404 → "Armband nicht zugewiesen" (even for configuration errors)
- Any 401 → Same generic message regardless of cause
- Any 400 → "Ungültige Anfrage" without specifics

This was because `mapServerErrorToGerman()` matched on generic HTTP status patterns instead of specific backend messages.

## Solution

Reordered and expanded error matching: **specific backend messages → generic status codes → fallback**

### Error Categories Added (48 total)

| Category | Count | Examples |
|----------|-------|----------|
| Authentication (401) | 7 | `invalid device API key`, `staff account is locked due to failed PIN attempts` |
| Authorization (403) | 2 | `device is not active`, `device is offline` |
| Session (400/409) | 6 | `device is already running an activity session`, `activity_id is required` |
| RFID (400/404) | 3 | `RFID tag not found`, `RFID tag not assigned to any person` |
| Attendance (404) | 3 | `no active visit found for student`, `person is not a student` |
| Staff (400/404) | 3 | `staff not found`, `staff has no RFID tag assigned` |
| Feedback (400/404) | 3 | `student_id is required and must be positive`, `student not found` |
| Validation (400) | 4 | `room_id is required for check-in`, `destination must be 'zuhause' or 'unterwegs'` |
| Internal (500) | 9 | `schulhof activity not configured`, `failed to create visit record` |
| Capacity (409) | 2 | `ROOM_CAPACITY_EXCEEDED`, `ACTIVITY_CAPACITY_EXCEEDED` |
| Generic fallbacks | 6 | 401, 403, 404, 409, 400, 5xx |

### Key Pattern Matching

| Frontend Pattern | Matches Backend Messages |
|------------------|-------------------------|
| `includes('RFID tag not assigned')` | "RFID tag not assigned to any person", "RFID tag not assigned to student or staff" |
| `includes('no active session')` | "no active session found", "no active session to end" |
| `includes('at least one supervisor')` | "at least one supervisor is required", "at least one supervisor ID is required" |

### Backend Source Verification

All messages verified against:
- `auth/device/errors.go`
- `api/iot/common/errors.go`
- `api/iot/checkin/workflow.go`
- `api/iot/sessions/handlers.go`
- `api/iot/attendance/handlers.go`
- `api/iot/feedback/handlers.go`
- `services/active/errors.go`

## Regression Fix

Restored lowercase `'not found'` matching in the generic 404 fallback. The initial comprehensive update accidentally removed this, which could cause unanticipated backend messages (e.g., `"resource not found"`) to display raw English text instead of the German translation.

This is safe because specific checks come **before** the generic fallback — they match and return immediately, so the fallback only catches messages that slipped through all specific checks.

## Test plan

- [ ] Wrong API URL shows "Ressource nicht gefunden. Bitte Konfiguration prüfen." on PIN entry
- [ ] RFID scan with unassigned tag shows "Armband ist nicht zugewiesen"
- [ ] Invalid PIN shows "Ungültiger PIN. Bitte erneut versuchen."
- [ ] Locked account shows specific lockout message
- [ ] Device already running session shows "Gerät führt bereits eine Aktivität durch"
- [ ] Missing supervisor shows "Mindestens ein Betreuer muss ausgewählt werden"
- [ ] Room capacity exceeded shows room-specific message
- [ ] Generic 500 errors show "Server nicht erreichbar. Bitte später versuchen."
- [ ] Unanticipated lowercase "not found" errors show German fallback (not raw English)