### PR TITLE
fix(rfid): prevent race condition in single scan by adding mutex

### DIFF
--- a/src-tauri/src/rfid.rs
+++ b/src-tauri/src/rfid.rs
@@ -903,6 +903,10 @@ pub async fn scan_rfid_single() -> Result<RfidScanResult, String> {
 
 #[tauri::command]
 pub async fn scan_rfid_with_timeout(timeout_seconds: u64) -> Result<RfidScanResult, String> {
+    // Acquire same mutex as scan_rfid_single to prevent concurrent SPI access
+    let mutex = ONESHOT_SCAN_MUTEX.get_or_init(|| TokioMutex::new(()));
+    let _guard = mutex.lock().await;
+
     // For future implementation - continuous scanning with custom timeout
     #[cfg(all(any(target_arch = "aarch64", target_arch = "arm"), target_os = "linux"))]
     {


### PR DESCRIPTION
## Summary

- Adds a `tokio::sync::Mutex` to serialize `scan_rfid_single` calls
- Prevents concurrent SPI access that corrupted MFRC522 chip state
- Fixes intermittent hangs on the Tag Assignment page when user cancels and restarts quickly

## Problem

When user on the armband scan page:
1. Started a scan
2. Cancelled before completion
3. Immediately started a new scan

Both Rust operations would run concurrently, sending conflicting commands to the MFRC522 via SPI. This corrupted the chip state, causing subsequent scans to hang.

## Solution

Added a mutex that serializes one-shot scans. If a second scan is requested while one is running, it waits for the first to complete (up to 10s timeout) rather than corrupting hardware state.

## Test plan

- [ ] Deploy to Pi and test rapid cancel/restart on Tag Assignment page
- [ ] Verify normal scan flow still works
- [ ] Verify timeout still triggers correctly after 10s