### PR TITLE
fix(nav): use history-based back navigation from PinPage

### DIFF
--- a/src/pages/PinPage.tsx
+++ b/src/pages/PinPage.tsx
@@ -154,9 +154,9 @@ function PinPage() {
   // Handle back button click
   const handleBack = () => {
     try {
-      logger.info('User navigating back to landing page');
-      logNavigation('PinPage', 'LandingPage');
-      void navigate('/');
+      logger.info('User navigating back from PinPage');
+      logNavigation('PinPage', 'back');
+      void navigate(-1);
     } catch (error) {
       logError(error instanceof Error ? error : new Error(String(error)), 'PinPage.handleBack');
     }


### PR DESCRIPTION
## Summary
- PinPage's back button was hardcoded to `navigate('/')`, causing a redirect to the landing page regardless of where the user came from
- When entering PinPage from ActivityScanningPage (`/nfc-scanning`) and pressing Back, the user landed on `/` instead of returning to `/nfc-scanning`
- Replaced `navigate('/')` with `navigate(-1)` to respect browser history stack

## Test plan
- [ ] From LandingPage → click Anmelden → PinPage → Back → should return to LandingPage
- [ ] From ActivityScanningPage → click Anmelden → PinPage → Back → should return to ActivityScanningPage