### PR TITLE
fix(team): sync selectedSupervisors with backend session state

### DIFF
--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -767,6 +767,13 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
         currentSession: session,
         selectedActivity: sessionActivity,
         selectedRoom: sessionRoom,
+        // Sync supervisors from backend → local cache
+        ...(session.supervisors && {
+          selectedSupervisors: session.supervisors.map(sup => ({
+            id: sup.staff_id,
+            name: sup.display_name,
+          })),
+        }),
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- `fetchCurrentSession()` now syncs `selectedSupervisors` from the backend response so the local cache stays in sync
- `TeamManagementPage` always refreshes supervisors from the backend on mount (removed stale `length === 0` guard)
- `handleSave()` updates the store with server-confirmed supervisors from the API response instead of trusting local data

## Test plan
- [ ] Start session with Supervisor A
- [ ] Open Team anpassen → should show A selected
- [ ] Change to Supervisor B, save
- [ ] Go home, re-open Team anpassen → should show B (not A)
- [ ] Verify `currentSession.supervisors` and `selectedSupervisors` stay in sync throughout
- [ ] `npm run check` passes

Closes #736