### PR TITLE
fix: prevent room selection race condition during session fetch

### DIFF
--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -234,14 +234,35 @@ const ActivityScanningPage: React.FC = () => {
   }, [showModal, currentScan]);
 
   // State consistency guard - detect and fix stale room state (Issue #129 Bug 1)
-  // Skips during recent manual room transitions to avoid ping-pong with stale server data
+  // Skips during recent manual room transitions to avoid ping-pong with stale server data.
+  // Schedules a deferred re-check so the guard runs once the transition window elapses.
   useEffect(() => {
     const roomSelectedAt = useUserStore.getState()._roomSelectedAt;
-    const isRecentTransition = roomSelectedAt != null && Date.now() - roomSelectedAt < 5000;
+    const remainingMs = roomSelectedAt != null ? 5000 - (Date.now() - roomSelectedAt) : 0;
+    const isRecentTransition = remainingMs > 0;
 
     if (isRecentTransition) {
-      logger.debug('Skipping room mismatch check during recent room transition');
-      return;
+      logger.debug(
+        'Skipping room mismatch check during recent room transition, re-checking after window'
+      );
+      const timeout = setTimeout(() => {
+        const state = useUserStore.getState();
+        if (
+          state.currentSession?.room_id &&
+          state.selectedRoom &&
+          state.selectedRoom.id !== state.currentSession.room_id
+        ) {
+          logger.warn(
+            'Deferred state inconsistency detected: selectedRoom does not match session',
+            {
+              selectedRoomId: state.selectedRoom.id,
+              sessionRoomId: state.currentSession.room_id,
+            }
+          );
+          void fetchCurrentSession();
+        }
+      }, remainingMs + 100); // small buffer past the 5s window
+      return () => clearTimeout(timeout);
     }
 
     if (currentSession?.room_id && selectedRoom && selectedRoom.id !== currentSession.room_id) {


### PR DESCRIPTION
## Summary
- `fetchCurrentSession()` was blindly overwriting `selectedRoom` with server data, causing the UI to jump back to a stale room after a manual room switch
- Added a 5-second grace period (`_roomSelectedAt` timestamp) that preserves the manually selected room when server data hasn't caught up yet
- Updated the room-mismatch guard in `ActivityScanningPage` to skip re-syncing during this transition window, breaking the ping-pong loop

## Root Cause

The race condition is **entirely client-side**. Backend analysis of the Project Phoenix server confirmed:

- `GET /iot/session/current` runs a single atomic query (`FindActiveByDeviceIDWithNames`) that JOINs `active.groups` with `facilities.rooms` — no caching, always hits the database fresh
- Room updates via `PUT /active/groups/{id}` write `room_id` directly to `active.groups` with no queue or delay — PostgreSQL strong consistency means the change is visible to the next SELECT immediately
- No eventual consistency, no versioning — the backend returns whatever is in the database at query time

The actual problem: `fetchCurrentSession()` fires *before* a room switch, but the response arrives *after* `selectRoom()` has already updated local state, overwriting it with stale data. The room-mismatch guard in `ActivityScanningPage` then detects the discrepancy and calls `fetchCurrentSession()` again, creating a ping-pong loop.

## Fix

Two targeted changes:

1. **`src/store/userStore.ts`** — New `_roomSelectedAt` timestamp set by `selectRoom()`. `fetchCurrentSession()` checks this timestamp and skips overwriting `selectedRoom` if the manual selection happened less than 5 seconds ago.
2. **`src/pages/ActivityScanningPage.tsx`** — Room-mismatch guard respects the same grace period, skipping the re-sync during recent room transitions.

## Follow-up fix (5a4d90e)

Addressed two edge cases in the original guard logic:

1. **Null session room now preserved** (`userStore.ts`) — If the backend returns a session without room data during the 5s grace period, the guard previously evaluated to `false` (because `sessionRoom != null` failed), overwriting the manual selection with `null`. Now treats a null `sessionRoom` as stale data and preserves the manual room.
2. **Deferred mismatch re-check** (`ActivityScanningPage.tsx`) — The early return during the transition window previously never scheduled a follow-up, so if no further state changes occurred the mismatch guard was permanently suppressed. Now schedules a `setTimeout` for the remaining window duration so the guard runs once the 5s period elapses.

## Test plan
- [ ] Start a session in room "Pink"
- [ ] End the session
- [ ] Start a new session in room "Weiß"
- [ ] Verify "Weiß" stays stable and doesn't jump back to "Pink"
- [ ] Check console logs: `Skipping room mismatch check` should appear briefly after room switch
- [ ] Verify room selection persists even if server briefly returns no room data
- [ ] After 5s, verify mismatch guard re-activates (check for `Deferred state inconsistency` log if mismatch exists)
- [ ] `npm run check` passes (TypeScript + ESLint)