### PR TITLE
feat(rfid): add processing spinner between scan and API response

### DIFF
--- a/src/components/ui/RfidProcessingIndicator.tsx
+++ b/src/components/ui/RfidProcessingIndicator.tsx
@@ -1,0 +1,50 @@
+import { memo } from 'react';
+
+interface RfidProcessingIndicatorProps {
+  readonly isVisible: boolean;
+}
+
+/**
+ * Fixed-position bottom-left spinner indicating an RFID scan is being processed by the API.
+ * Mirrors the NetworkStatus indicator positioning (bottom-right) but on the opposite corner.
+ * Shows between RFID tag detection (Rust backend) and API response.
+ */
+const RfidProcessingIndicator = memo(function RfidProcessingIndicator({
+  isVisible,
+}: RfidProcessingIndicatorProps) {
+  if (!isVisible) return null;
+
+  return (
+    <>
+      <style>{`
+        @keyframes rfid-processing-spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+      `}</style>
+      <div
+        style={{
+          position: 'fixed',
+          bottom: '8px',
+          left: '8px',
+          zIndex: 1000,
+          pointerEvents: 'none',
+          padding: '12px',
+        }}
+      >
+        <div
+          style={{
+            width: '48px',
+            height: '48px',
+            border: '4px solid rgba(80, 128, 216, 0.2)',
+            borderTopColor: '#5080D8',
+            borderRadius: '50%',
+            animation: 'rfid-processing-spin 0.8s linear infinite',
+          }}
+        />
+      </div>
+    </>
+  );
+});
+
+export default RfidProcessingIndicator;

--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -376,9 +376,8 @@ export const useRfidScanning = () => {
       const startTime = Date.now();
 
       try {
-        // Show optimistic UI feedback
+        // Track optimistic scan state (no modal yet - wait for API response)
         addOptimisticScan(createOptimisticScan(scanId, tagId));
-        showScanModal();
         logger.info('Starting network scan (cache disabled)');
         updateOptimisticScan(scanId, 'processing');
 
@@ -426,6 +425,9 @@ export const useRfidScanning = () => {
           updateStudentHistory,
           recordTagScan,
         });
+
+        // Show result modal now that we have real data (not optimistic)
+        showScanModal();
 
         // Update session activity (fire-and-forget)
         try {

--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { BackgroundWrapper } from '../components/background-wrapper';
 import { ModalBase } from '../components/ui';
 import BackButton from '../components/ui/BackButton';
+import RfidProcessingIndicator from '../components/ui/RfidProcessingIndicator';
 import { useRfidScanning } from '../hooks/useRfidScanning';
 import {
   api,
@@ -1296,6 +1297,9 @@ const ActivityScanningPage: React.FC = () => {
           {renderModalContent()}
         </ModalBase>
       )}
+
+      {/* Bottom-left spinner: visible between RFID tag detection and API response */}
+      <RfidProcessingIndicator isVisible={rfid.processingQueue.size > 0} />
     </>
   );
 };

--- a/src/pages/TagAssignmentPage.tsx
+++ b/src/pages/TagAssignmentPage.tsx
@@ -6,6 +6,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { BackgroundWrapper } from '../components/background-wrapper';
 import { ErrorModal, ModalBase } from '../components/ui';
 import BackButton from '../components/ui/BackButton';
+import RfidProcessingIndicator from '../components/ui/RfidProcessingIndicator';
 import { api, type TagAssignmentCheck } from '../services/api';
 import { useUserStore } from '../store/userStore';
 import { designSystem } from '../styles/designSystem';
@@ -893,6 +894,9 @@ function TagAssignmentPage() {
         message={error ?? ''}
         autoCloseDelay={3000}
       />
+
+      {/* Bottom-left spinner: visible between RFID tag detection and API response */}
+      <RfidProcessingIndicator isVisible={isLoading && !!scannedTag} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a non-intrusive bottom-left spinner (mirrors the NetworkStatus indicator at bottom-right) that shows between RFID tag detection by the Rust backend and the API response
- Moves `showScanModal()` to after `setScanResult()` in the scanning hook, eliminating modal flickering from stale/optimistic data
- Helps users distinguish between a faulty RFID scanner and a slow API

## How to test

### Setup
1. `npm run dev` (frontend-only, uses mock RFID scanning)
2. Log in with a valid PIN and start a session to reach the ActivityScanningPage

### Testing the spinner on ActivityScanningPage
The mock scanner fires automatically every 5-10s. On each mock scan you should see:
1. A blue spinning circle appears at the **bottom-left** corner
2. The spinner disappears when the result modal appears with real data
3. No flicker of stale/old scan data in the modal

Note: If the API responds quickly, the spinner may only flash briefly. To observe it more clearly, throttle the network in browser DevTools (e.g. "Slow 3G").

### Testing the spinner on TagAssignmentPage
1. Navigate to Home → "Armband scannen" (tag assignment)
2. Click "Scan starten"
3. After the mock scan completes (~2s), the spinner appears at bottom-left while the API checks the tag assignment
4. Spinner disappears when the assignment card renders

### Edge cases to verify
- [ ] **Rapid scans**: Wait for two mock scans in quick succession — spinner should not get stuck
- [ ] **Error responses**: If the API returns an error, spinner disappears and error modal shows
- [ ] **No flicker**: The result modal should never briefly show a previous student's name
- [ ] **Position**: Spinner is at bottom-left (`left: 8px, bottom: 8px`), NetworkStatus (when offline) is at bottom-right — they don't overlap

## Test plan
- [ ] Trigger RFID scan on ActivityScanningPage — spinner appears at bottom-left during API call, disappears when result modal shows
- [ ] Trigger RFID scan on TagAssignmentPage — spinner appears after tag detected, disappears when assignment card shows
- [ ] Verify no modal flicker with stale data from previous scans
- [ ] Verify rapid successive scans don't break spinner state