### PR TITLE
fix(rfid): clear stale tag caches on reassignment

### DIFF
--- a/src/pages/StudentSelectionPage.tsx
+++ b/src/pages/StudentSelectionPage.tsx
@@ -31,7 +31,7 @@ interface LocationState {
 }
 
 function StudentSelectionPage() {
-  const { authenticatedUser, selectedSupervisors } = useUserStore();
+  const { authenticatedUser, selectedSupervisors, clearTagScan } = useUserStore();
   const navigate = useNavigate();
   const location = useLocation();
   const state = location.state as LocationState;
@@ -233,6 +233,8 @@ function StudentSelectionPage() {
             );
 
       if (result.success) {
+        clearTagScan(state.scannedTag);
+
         logUserAction('tag_assignment_complete', {
           type: selectedEntity.type,
           tagId: state.scannedTag,

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -556,8 +556,8 @@ const SESSION_INITIAL_STATE = {
 };
 
 // RFID state that should be cleared on session change
-// Note: tagToStudentMap is intentionally NOT cleared - it maps RFID tags to student IDs
-// which remains useful across sessions
+// Note: tagToStudentMap is NOT cleared on session change (useful across sessions),
+// but IS cleared per-tag via clearTagScan() on tag reassignment
 const RFID_SESSION_INITIAL_STATE = {
   recentTagScans: new Map<string, RecentTagScan>(),
   studentHistory: new Map<string, StudentActionHistory>(),
@@ -1498,8 +1498,23 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
     set(state => {
       const newScans = new Map(state.rfid.recentTagScans);
       newScans.delete(tagId);
+
+      const newTagMap = new Map(state.rfid.tagToStudentMap);
+      const oldStudentId = newTagMap.get(tagId);
+      newTagMap.delete(tagId);
+
+      const newHistory = new Map(state.rfid.studentHistory);
+      if (oldStudentId) {
+        newHistory.delete(oldStudentId);
+      }
+
       return {
-        rfid: { ...state.rfid, recentTagScans: newScans },
+        rfid: {
+          ...state.rfid,
+          recentTagScans: newScans,
+          tagToStudentMap: newTagMap,
+          studentHistory: newHistory,
+        },
       };
     });
   },


### PR DESCRIPTION
## Summary

- Expands `clearTagScan` in the Zustand store to evict all three in-memory RFID caches (`recentTagScans`, `tagToStudentMap`, `studentHistory`) in a single batched `set()` call
- Calls `clearTagScan` in `StudentSelectionPage` after a successful tag assignment, so the next scan hits the server fresh
- Updates the comment on `RFID_SESSION_INITIAL_STATE` to reflect the new per-tag clearing behavior

Closes #237

## Test plan

- [ ] `npm run check` passes (ESLint + TypeScript)
- [ ] Start session, scan a tag, note student name
- [ ] Go to tag assignment, reassign same tag to a different person
- [ ] Return to scanning, scan same tag — verify new student name shown, no stale data