### PR TITLE
fix(deps): update bytes to 1.11.1 (CVE-2026-25541)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -323,9 +323,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
## Summary
- Updates `bytes` crate from 1.10.1 to 1.11.1 to fix integer overflow in `BytesMut::reserve`
- Addresses Dependabot alert #5 (CVE-2026-25541 / GHSA-434x-w66g-qw3r)
- Original Dependabot PR #242 was closed, so this applies the fix manually via `cargo update -p bytes`

## Test plan
- [ ] `cargo clippy` passes in `src-tauri/`
- [ ] `npm run check` passes