### PR TITLE
perf: reduce buttonless scan modal duration from 2s to 1.5s

### DIFF
--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -35,9 +35,9 @@ const DAILY_CHECKOUT_TIMEOUT_MS = 7000;
 
 /**
  * Timeout duration (in milliseconds) for farewell messages after actions.
- * 2 seconds is enough to read a short goodbye message.
+ * 1.5 seconds is enough to read a short goodbye message while keeping queue throughput high.
  */
-const FAREWELL_TIMEOUT_MS = 2000;
+const FAREWELL_TIMEOUT_MS = 1500;
 
 // Feedback button color schemes: green (positive), yellow (neutral), red (negative)
 const FEEDBACK_BUTTON_COLORS = {

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -407,7 +407,7 @@ interface RfidState {
   currentScan: RfidScanResult | null;
   blockedTags: Map<string, number>; // tagId -> blockUntilTimestamp
   scanTimeout: number; // 3 seconds default
-  modalDisplayTime: number; // 1.25 seconds default
+  modalDisplayTime: number; // 1.5 seconds default
   showModal: boolean;
 
   // New optimistic state management
@@ -606,7 +606,7 @@ const createUserStore = (set: SetState<UserState>, get: GetState<UserState>) => 
     currentScan: null,
     blockedTags: new Map<string, number>(),
     scanTimeout: 3000, // 3 seconds
-    modalDisplayTime: 2000, // 2 seconds - balanced for animation viewing
+    modalDisplayTime: 1500, // 1.5 seconds - fast turnover for kiosk queues
     showModal: false,
 
     // New optimistic state


### PR DESCRIPTION
## Summary
- Reduce `modalDisplayTime` (scan result modals) from 2000ms to 1500ms
- Reduce `FAREWELL_TIMEOUT_MS` (goodbye after checkout) from 2000ms to 1500ms
- `DAILY_CHECKOUT_TIMEOUT_MS` (modals with buttons) unchanged at 7000ms

Saves 500ms per scan — adds up fast with a queue of students at the kiosk.

## Test plan
- [ ] Run `npm run tauri dev`, scan mock RFID tags, confirm success modals dismiss faster
- [ ] Verify checkout destination modal (with buttons) still shows for 7s
- [ ] Confirm farewell message after checkout is still readable at 1.5s