### PR TITLE
feat: consume device config endpoint for checkout button visibility

### DIFF
--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -20,6 +20,7 @@ import {
   mapServerErrorToGerman,
   type RfidScanResult,
   type DailyFeedbackRating,
+  type DeviceConfig,
 } from '../services/api';
 import { useUserStore, isNetworkRelatedError } from '../store/userStore';
 import { createLogger, serializeError } from '../utils/logger';
@@ -386,6 +387,9 @@ const ActivityScanningPage: React.FC = () => {
   // WC room ID (discovered dynamically from server)
   const [wcRoomId, setWcRoomId] = useState<number | null>(null);
 
+  // Device config (checkout button visibility, fetched once on mount)
+  const [deviceConfig, setDeviceConfig] = useState<DeviceConfig | null>(null);
+
   // Pickup query prompt state
   const [isAwaitingPickupQueryScan, setIsAwaitingPickupQueryScan] = useState(false);
   const isPickupQueryLoading =
@@ -521,6 +525,27 @@ const ActivityScanningPage: React.FC = () => {
 
     void fetchSchulhofRoom();
   }, [authenticatedUser?.pin]);
+
+  // Fetch device config once on mount (checkout button visibility, feedback settings)
+  useEffect(() => {
+    const fetchDeviceConfig = async () => {
+      try {
+        const config = await api.getDeviceConfig();
+        setDeviceConfig(config);
+        logger.info('Device config loaded', {
+          raumwechsel: config.checkout.raumwechsel_enabled,
+          schulhof: config.checkout.schulhof_enabled,
+          wc: config.checkout.wc_enabled,
+          feedbackEnabled: config.feedback.enabled,
+        });
+      } catch (error) {
+        logger.error('Failed to fetch device config', { error: serializeError(error) });
+        // Non-critical — buttons default to visible when config is unavailable
+      }
+    };
+
+    void fetchDeviceConfig();
+  }, []);
 
   // Update student count based on scan result
   // Refactored to use extracted helper functions (SonarCloud S3776 fix)
@@ -1096,28 +1121,32 @@ const ActivityScanningPage: React.FC = () => {
         colorScheme?: keyof typeof DESTINATION_COLORS;
         onClick: () => void;
       }[] = [
-        {
-          destination: 'raumwechsel',
-          label: 'Raumwechsel',
-          icon: (
-            <svg
-              width="48"
-              height="48"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="white"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-              <polyline points="16 17 21 12 16 7" />
-              <line x1="21" y1="12" x2="9" y2="12" />
-            </svg>
-          ),
-          onClick: () => void handleDestinationSelect('raumwechsel'),
-        },
-        ...(schulhofRoomId
+        ...(deviceConfig?.checkout.raumwechsel_enabled !== false
+          ? [
+              {
+                destination: 'raumwechsel' as const,
+                label: 'Raumwechsel',
+                icon: (
+                  <svg
+                    width="48"
+                    height="48"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                    <polyline points="16 17 21 12 16 7" />
+                    <line x1="21" y1="12" x2="9" y2="12" />
+                  </svg>
+                ),
+                onClick: () => void handleDestinationSelect('raumwechsel'),
+              },
+            ]
+          : []),
+        ...(schulhofRoomId && deviceConfig?.checkout.schulhof_enabled !== false
           ? [
               {
                 destination: 'schulhof' as const,
@@ -1156,7 +1185,7 @@ const ActivityScanningPage: React.FC = () => {
               },
             ]
           : []),
-        ...(wcRoomId
+        ...(wcRoomId && deviceConfig?.checkout.wc_enabled !== false
           ? [
               {
                 destination: 'toilette' as const,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1422,7 +1422,39 @@ export const api = {
       throw new Error(mapAttendanceErrorToGerman(errorMessage, 'feedback'));
     }
   },
+
+  /**
+   * Get device configuration (checkout button visibility, feedback settings)
+   * Endpoint: GET /api/iot/config
+   * Auth: Device API key only (no PIN required)
+   */
+  async getDeviceConfig(): Promise<DeviceConfig> {
+    const response = await apiCall<{ status: string; data: DeviceConfig }>('/api/iot/config', {
+      headers: {
+        Authorization: `Bearer ${DEVICE_API_KEY}`,
+      },
+    });
+
+    return response.data;
+  },
 };
+
+/**
+ * Device configuration returned by GET /api/iot/config.
+ * Controls which buttons appear on the checkout screen and whether feedback is shown.
+ */
+export interface DeviceConfig {
+  checkout: {
+    raumwechsel_enabled: boolean;
+    schulhof_enabled: boolean;
+    wc_enabled: boolean;
+    /** "HH:MM" or null (null = "nach Hause" always available) */
+    daily_checkout_time: string | null;
+  };
+  feedback: {
+    enabled: boolean;
+  };
+}
 
 /**
  * Student data structure from /api/iot/students


### PR DESCRIPTION
## Summary

- Fetch `GET /api/iot/config` on page mount to get per-tenant checkout button settings
- Conditionally render Raumwechsel, Schulhof, and Toilette buttons based on config
- Graceful degradation: buttons default to visible if config fetch fails

Companion to moto-nrw/project-phoenix#1232 which adds the backend settings, "Geräte" admin tab, and config endpoint.

## Changes

**`src/services/api.ts`**
- Added `DeviceConfig` interface (exported)
- Added `api.getDeviceConfig()` — device API key only, no PIN required

**`src/pages/ActivityScanningPage.tsx`**
- Added `deviceConfig` state + `useEffect` fetch on mount
- Raumwechsel: now gated by `checkout.raumwechsel_enabled`
- Schulhof: added `checkout.schulhof_enabled` check alongside existing room existence check
- Toilette: added `checkout.wc_enabled` check alongside existing room existence check
- nach Hause: unchanged — `daily_checkout_available` is already computed server-side per scan

## What this does NOT change

- **Feedback flow** — already reads `feedback_enabled` from `toggleAttendance` response (line 744)
- **Daily checkout time** — backend computes `daily_checkout_available` per scan, PyrePortal just reads the boolean

## Test plan

- [ ] Deploy Phoenix with #1232 merged, verify `GET /api/iot/config` returns expected defaults
- [ ] Toggle settings in admin UI "Geräte" tab, verify buttons appear/disappear on kiosk
- [ ] Verify buttons still show when config endpoint is unreachable (graceful degradation)
- [ ] Verify nach Hause button still works as before (no behavioral change)
- [ ] Verify feedback flow still works as before