### PR TITLE
Improve checkout modal sizing and fix empty destinations bug

### DIFF
--- a/src/components/ui/ModalBase.tsx
+++ b/src/components/ui/ModalBase.tsx
@@ -260,7 +260,7 @@ export function ModalBase({
           padding: sizePreset.padding,
           maxWidth: sizePreset.maxWidth,
           width: autoWidth ? 'fit-content' : '90vw',
-          minWidth: autoWidth ? '300px' : undefined,
+          minWidth: autoWidth ? '450px' : undefined,
           textAlign: 'center',
           boxShadow: '0 20px 50px rgba(0, 0, 0, 0.3)',
           position: 'relative',

--- a/src/components/ui/ModalBase.tsx
+++ b/src/components/ui/ModalBase.tsx
@@ -260,7 +260,7 @@ export function ModalBase({
           padding: sizePreset.padding,
           maxWidth: sizePreset.maxWidth,
           width: autoWidth ? 'fit-content' : '90vw',
-          minWidth: autoWidth ? '450px' : undefined,
+          minWidth: autoWidth ? '700px' : undefined,
           textAlign: 'center',
           boxShadow: '0 20px 50px rgba(0, 0, 0, 0.3)',
           position: 'relative',

--- a/src/components/ui/ModalBase.tsx
+++ b/src/components/ui/ModalBase.tsx
@@ -10,9 +10,9 @@ type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
 /** Size preset configurations matching existing modal dimensions */
 const SIZE_PRESETS = {
   sm: { maxWidth: '500px', padding: '48px', borderRadius: '20px' }, // ErrorModal, SuccessModal, InfoModal
-  md: { maxWidth: '600px', padding: '56px', borderRadius: '24px' }, // Future use
+  md: { maxWidth: '600px', padding: '56px', borderRadius: '24px' }, // GroupPicker, TagAssignment scanner
   lg: { maxWidth: '700px', padding: '64px', borderRadius: '32px' }, // ActivityScanningPage (current default)
-  xl: { maxWidth: '1060px', padding: '64px', borderRadius: '32px' }, // Wide modals (e.g., 3-button checkout destination)
+  xl: { maxWidth: '1060px', padding: '64px', borderRadius: '32px' }, // Wide modals (e.g., 4-button checkout)
 } as const;
 
 /**
@@ -60,6 +60,9 @@ interface ModalBaseProps {
 
   /** Backdrop blur amount. Default: '4px' */
   backdropBlur?: string;
+
+  /** Use fit-content width instead of 90vw. Default: false */
+  autoWidth?: boolean;
 
   // --- Timeout ---
 
@@ -129,6 +132,7 @@ export function ModalBase({
   onTimeout,
   timeoutColor,
   timeoutTrackColor,
+  autoWidth = false,
   closeOnBackdropClick = true,
   closeOnContentClick = false,
   closeOnEscapeKey = true,
@@ -255,7 +259,8 @@ export function ModalBase({
           borderRadius: sizePreset.borderRadius,
           padding: sizePreset.padding,
           maxWidth: sizePreset.maxWidth,
-          width: '90vw',
+          width: autoWidth ? 'fit-content' : '90vw',
+          minWidth: autoWidth ? '300px' : undefined,
           textAlign: 'center',
           boxShadow: '0 20px 50px rgba(0, 0, 0, 0.3)',
           position: 'relative',

--- a/src/pages/ActivityScanningPage.test.tsx
+++ b/src/pages/ActivityScanningPage.test.tsx
@@ -680,7 +680,7 @@ describe('ActivityScanningPage', () => {
     await user.click(screen.getByText('Raumwechsel'));
     // After clicking Raumwechsel, destination state is cleared —
     // the modal should show the checked_out confirmation instead of destination buttons
-    expect(screen.getByText('Lisa ist unterwegs')).toBeInTheDocument();
+    expect(screen.getByText('Tschüss, Lisa!')).toBeInTheDocument();
   });
 
   // =======================================================================
@@ -2075,7 +2075,7 @@ describe('ActivityScanningPage', () => {
     renderPage();
     expect(screen.getByText('Raumwechsel')).toBeInTheDocument();
     await user.click(screen.getByText('Raumwechsel'));
-    expect(screen.getByText('Max ist unterwegs')).toBeInTheDocument();
+    expect(screen.getByText('Tschüss, Max!')).toBeInTheDocument();
   });
 
   // =======================================================================

--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -110,11 +110,12 @@ const DESTINATION_BUTTON_STYLES = {
     color: '#FFFFFF',
     fontSize: '32px',
     fontWeight: 700,
-    padding: '32px 48px',
+    padding: '28px 36px',
     cursor: 'pointer',
     transition: 'all 200ms',
     outline: 'none',
-    width: '280px',
+    width: '200px',
+    aspectRatio: '5 / 4',
   },
   hover: {
     backgroundColor: 'rgba(255, 255, 255, 0.35)',
@@ -133,6 +134,69 @@ const DESTINATION_COLORS = {
   toilette: { bg: 'rgba(96, 165, 250, 0.85)', bgHover: 'rgba(96, 165, 250, 0.95)' },
   destructive: { bg: 'rgba(220, 38, 38, 0.5)', bgHover: 'rgba(220, 38, 38, 0.65)' },
 };
+
+// Static SVG icons hoisted out of render path to avoid per-render allocation on Pi
+const ICON_RAUMWECHSEL = (
+  <svg
+    width="48"
+    height="48"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="white"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <polyline points="16 17 21 12 16 7" />
+    <line x1="21" y1="12" x2="9" y2="12" />
+  </svg>
+);
+
+const ICON_SCHULHOF = (
+  <svg
+    width="48"
+    height="48"
+    viewBox="0 0 64 64"
+    fill="none"
+    stroke="#FFFFFF"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {/* Top horizontal bar */}
+    <line x1="6" y1="8" x2="58" y2="8" strokeWidth="3" />
+    {/* Left A-leg front */}
+    <line x1="6" y1="8" x2="12" y2="58" />
+    {/* Left A-leg back */}
+    <line x1="6" y1="8" x2="2" y2="58" />
+    {/* Right A-leg front */}
+    <line x1="58" y1="8" x2="52" y2="58" />
+    {/* Right A-leg back */}
+    <line x1="58" y1="8" x2="62" y2="58" />
+    {/* Left chain */}
+    <line x1="24" y1="8" x2="22" y2="40" />
+    {/* Right chain */}
+    <line x1="40" y1="8" x2="42" y2="40" />
+    {/* Seat */}
+    <rect x="19" y="40" width="26" height="4" rx="2" fill="#FFFFFF" />
+  </svg>
+);
+
+const ICON_NACH_HAUSE = (
+  <svg
+    width="48"
+    height="48"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="white"
+    strokeWidth="2.2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+  </svg>
+);
 
 /** Reusable destination button for checkout modal */
 function DestinationButton({
@@ -161,6 +225,7 @@ function DestinationButton({
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
+        justifyContent: 'center',
         gap: '12px',
       }}
       onPointerDown={e => {
@@ -389,6 +454,17 @@ const ActivityScanningPage: React.FC = () => {
 
   // Device config (checkout button visibility, fetched once on mount)
   const [deviceConfig, setDeviceConfig] = useState<DeviceConfig | null>(null);
+
+  // Compute how many destination buttons will be visible (drives modal size)
+  const destinationCount = useMemo(() => {
+    if (!checkoutDestinationState || checkoutDestinationState.showingFarewell) return 0;
+    let count = 0;
+    if (deviceConfig?.checkout.raumwechsel_enabled !== false) count++;
+    if (schulhofRoomId && deviceConfig?.checkout.schulhof_enabled !== false) count++;
+    if (wcRoomId && deviceConfig?.checkout.wc_enabled !== false) count++;
+    if (checkoutDestinationState.dailyCheckoutAvailable) count++;
+    return count;
+  }, [deviceConfig, schulhofRoomId, wcRoomId, checkoutDestinationState]);
 
   // Pickup query prompt state
   const [isAwaitingPickupQueryScan, setIsAwaitingPickupQueryScan] = useState(false);
@@ -1126,22 +1202,7 @@ const ActivityScanningPage: React.FC = () => {
               {
                 destination: 'raumwechsel' as const,
                 label: 'Raumwechsel',
-                icon: (
-                  <svg
-                    width="48"
-                    height="48"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="white"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-                    <polyline points="16 17 21 12 16 7" />
-                    <line x1="21" y1="12" x2="9" y2="12" />
-                  </svg>
-                ),
+                icon: ICON_RAUMWECHSEL,
                 onClick: () => void handleDestinationSelect('raumwechsel'),
               },
             ]
@@ -1152,35 +1213,7 @@ const ActivityScanningPage: React.FC = () => {
                 destination: 'schulhof' as const,
                 label: 'Schulhof',
                 colorScheme: 'schulhof' as const,
-                icon: (
-                  <svg
-                    width="48"
-                    height="48"
-                    viewBox="0 0 64 64"
-                    fill="none"
-                    stroke="#FFFFFF"
-                    strokeWidth="2.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    {/* Top horizontal bar */}
-                    <line x1="6" y1="8" x2="58" y2="8" strokeWidth="3" />
-                    {/* Left A-leg front */}
-                    <line x1="6" y1="8" x2="12" y2="58" />
-                    {/* Left A-leg back */}
-                    <line x1="6" y1="8" x2="2" y2="58" />
-                    {/* Right A-leg front */}
-                    <line x1="58" y1="8" x2="52" y2="58" />
-                    {/* Right A-leg back */}
-                    <line x1="58" y1="8" x2="62" y2="58" />
-                    {/* Left chain */}
-                    <line x1="24" y1="8" x2="22" y2="40" />
-                    {/* Right chain */}
-                    <line x1="40" y1="8" x2="42" y2="40" />
-                    {/* Seat */}
-                    <rect x="19" y="40" width="26" height="4" rx="2" fill="#FFFFFF" />
-                  </svg>
-                ),
+                icon: ICON_SCHULHOF,
                 onClick: () => void handleDestinationSelect('schulhof'),
               },
             ]
@@ -1207,25 +1240,19 @@ const ActivityScanningPage: React.FC = () => {
                 destination: 'nach_hause' as const,
                 label: 'nach Hause',
                 colorScheme: 'destructive' as const,
-                icon: (
-                  <svg
-                    width="48"
-                    height="48"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="white"
-                    strokeWidth="2.2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-                  </svg>
-                ),
+                icon: ICON_NACH_HAUSE,
                 onClick: handleNachHause,
               },
             ]
           : []),
       ];
+
+      // No destinations available — skip straight to farewell instead of showing
+      // "Wohin geht X?" with an empty button grid
+      if (destinations.length === 0) {
+        setCheckoutDestinationState(prev => (prev ? { ...prev, showingFarewell: true } : null));
+        return null;
+      }
 
       // Determine grid columns: 2x2 for 3-4 buttons, single row for 1-2
       const gridColumns = destinations.length >= 3 ? 2 : destinations.length;
@@ -1567,13 +1594,16 @@ const ActivityScanningPage: React.FC = () => {
         <ModalBase
           isOpen={shouldShowCheckModal}
           onClose={handleModalTimeout}
+          autoWidth
           size={
             !isPickupQueryPromptOpen &&
             !showFeedbackPrompt &&
             currentScan?.action === 'checked_out' &&
             checkoutDestinationState &&
             !checkoutDestinationState.showingFarewell
-              ? 'xl'
+              ? destinationCount >= 3
+                ? 'xl'
+                : 'lg'
               : 'lg'
           }
           backgroundColor={(() => {
@@ -1828,10 +1858,10 @@ const ActivityScanningPage: React.FC = () => {
                 return `Wohin geht ${firstName}?`;
               }
 
-              // Checkout after destination selected (e.g. Raumwechsel): confirmation
+              // Checkout farewell: after destination selected or no destinations available
               if (currentScan?.action === 'checked_out') {
                 const firstName = (currentScan?.student_name ?? '').split(' ')[0];
-                return `${firstName} ist unterwegs`;
+                return `Tschüss, ${firstName}!`;
               }
 
               // Fallback: use backend message or student name

--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -114,7 +114,7 @@ const DESTINATION_BUTTON_STYLES = {
     cursor: 'pointer',
     transition: 'all 200ms',
     outline: 'none',
-    width: '200px',
+    width: '240px',
     aspectRatio: '5 / 4',
   },
   hover: {


### PR DESCRIPTION
## Summary

- **Fix**: Empty destinations bug — when all checkout buttons are disabled via device config and `dailyCheckoutAvailable` is false, the modal now skips "Wohin geht X?" and shows a farewell instead of an empty grid
- **Perf**: Hoist static SVG icons (Raumwechsel, Schulhof, nach Hause) to module scope to avoid per-render allocation on Pi
- **UI**: Add `autoWidth` prop to `ModalBase` — opt-in `fit-content` sizing so the checkout modal wraps its content instead of stretching to 90vw
- **UI**: Dynamic modal size based on destination count (lg for 1-2 buttons, xl for 3-4)
- **UI**: Destination buttons now 200px wide with 5:4 aspect ratio (was 280px square)
- **UI**: Farewell text changed from "{name} ist unterwegs" to "Tschüss, {name}!"

## Test plan

- [ ] Check-in scan: modal still shows correctly (green, "Hallo, X!")
- [ ] Checkout with 2 buttons (e.g. Raumwechsel + Schulhof): modal is compact, not full-width
- [ ] Checkout with 3-4 buttons: modal uses wider xl size with 2x2 grid
- [ ] Checkout with 0 buttons (all disabled in config, no daily checkout): shows "Tschüss, X!" farewell, no empty grid
- [ ] Aufsicht starten/wiederholen modals: unchanged, still full-width
- [ ] Error/Success modals: unchanged