### PR TITLE
fix(checkin): handle STUDENT_ALREADY_ACTIVE 409 from backend

### DIFF
--- a/src/hooks/useRfidScanning.test.ts
+++ b/src/hooks/useRfidScanning.test.ts
@@ -40,6 +40,10 @@ vi.mock('../services/api', () => ({
     updateSessionSupervisors: vi.fn(),
   },
   mapApiErrorToGerman: vi.fn(() => 'Ein Fehler ist aufgetreten'),
+  // Mirror the real `formatRoomName` translation table (currently just
+  // WC → Toilette) so the duplicate-active-visit modal renders the
+  // user-facing room name. Keep this in sync with src/services/api.ts.
+  formatRoomName: vi.fn((name: string) => (name === 'WC' ? 'Toilette' : name)),
   ApiError: class ApiError extends Error {
     public readonly code?: string;
     public readonly details?: Record<string, unknown>;
@@ -1030,8 +1034,11 @@ describe('useRfidScanning', () => {
     // Degraded 409 path: backend lookup of the existing visit failed (race
     // window in buildStudentAlreadyActiveResponse), so room_name is absent.
     // The modal must still trigger the friendly "already_in" state and use
-    // the generic fallback wording instead of the old, often-wrong "in
-    // diesem Raum" copy.
+    // the neutral fallback wording. We deliberately do NOT claim "in einem
+    // anderen Raum" here — the lookup failure means we don't actually know
+    // whether it's the same room or a different one, and guessing wrong
+    // sends staff to the wrong place. The copy mirrors
+    // mapApiErrorToGerman()'s generic fallback for the same scenario.
     it('falls back to generic copy when STUDENT_ALREADY_ACTIVE lacks room_name', async () => {
       const { ApiError: MockedApiError } = await import('../services/api');
       const duplicateError = new MockedApiError(
@@ -1053,9 +1060,40 @@ describe('useRfidScanning', () => {
       const state = useUserStore.getState();
       expect(state.rfid.currentScan?.action).toBe('already_in');
       expect(state.rfid.currentScan?.isInfo).toBe(true);
-      expect(state.rfid.currentScan?.message).toBe(
-        'Schüler*in ist bereits in einem anderen Raum angemeldet.'
+      expect(state.rfid.currentScan?.message).toBe('Schüler*in ist bereits angemeldet.');
+    });
+
+    // Issue #844 review fix: when the backend returns the internal "WC"
+    // room name, the modal must translate it to "Toilette" so the kiosk
+    // copy stays consistent with the rest of the UI (and with
+    // mapApiErrorToGerman, which already does this translation for the
+    // generic German error message).
+    it('translates internal WC room name to Toilette in already_in modal', async () => {
+      const { ApiError: MockedApiError } = await import('../services/api');
+      const duplicateError = new MockedApiError(
+        'API Error: 409 - Conflict: student already has an active visit',
+        409,
+        'STUDENT_ALREADY_ACTIVE',
+        {
+          student_id: 231,
+          existing_visit_id: 9002,
+          room_id: 7,
+          room_name: 'WC',
+        }
       );
+      mockedProcessRfidScan.mockRejectedValue(duplicateError);
+
+      const { result } = renderHook(() => useRfidScanning());
+
+      await act(async () => {
+        await result.current.startScanning();
+      });
+
+      await triggerMockScanAndDrain();
+
+      const state = useUserStore.getState();
+      expect(state.rfid.currentScan?.action).toBe('already_in');
+      expect(state.rfid.currentScan?.message).toBe('Bereits angemeldet in Toilette.');
     });
 
     it('handles room capacity exceeded error', async () => {

--- a/src/hooks/useRfidScanning.test.ts
+++ b/src/hooks/useRfidScanning.test.ts
@@ -992,6 +992,72 @@ describe('useRfidScanning', () => {
       expect(state.rfid.currentScan?.isInfo).toBe(true);
     });
 
+    // Issue #844: backend now returns 409 with code STUDENT_ALREADY_ACTIVE
+    // and details.room_name pointing at the room the student is actually in
+    // (which is often NOT the room being scanned). The modal must surface
+    // that room name so the user knows where to look for the kid.
+    it('shows existing room name from STUDENT_ALREADY_ACTIVE details', async () => {
+      const { ApiError: MockedApiError } = await import('../services/api');
+      const duplicateError = new MockedApiError(
+        'API Error: 409 - Conflict: student already has an active visit',
+        409,
+        'STUDENT_ALREADY_ACTIVE',
+        {
+          student_id: 231,
+          existing_visit_id: 9001,
+          room_id: 42,
+          room_name: 'Raum 1A',
+          entry_time: '2026-04-29T12:30:00Z',
+        }
+      );
+      mockedProcessRfidScan.mockRejectedValue(duplicateError);
+
+      const { result } = renderHook(() => useRfidScanning());
+
+      await act(async () => {
+        await result.current.startScanning();
+      });
+
+      await triggerMockScanAndDrain();
+
+      const state = useUserStore.getState();
+      expect(state.rfid.currentScan?.student_name).toBe('Bereits eingecheckt');
+      expect(state.rfid.currentScan?.action).toBe('already_in');
+      expect(state.rfid.currentScan?.isInfo).toBe(true);
+      expect(state.rfid.currentScan?.message).toBe('Bereits angemeldet in Raum 1A.');
+    });
+
+    // Degraded 409 path: backend lookup of the existing visit failed (race
+    // window in buildStudentAlreadyActiveResponse), so room_name is absent.
+    // The modal must still trigger the friendly "already_in" state and use
+    // the generic fallback wording instead of the old, often-wrong "in
+    // diesem Raum" copy.
+    it('falls back to generic copy when STUDENT_ALREADY_ACTIVE lacks room_name', async () => {
+      const { ApiError: MockedApiError } = await import('../services/api');
+      const duplicateError = new MockedApiError(
+        'API Error: 409 - Conflict: student already has an active visit',
+        409,
+        'STUDENT_ALREADY_ACTIVE',
+        { student_id: 231 }
+      );
+      mockedProcessRfidScan.mockRejectedValue(duplicateError);
+
+      const { result } = renderHook(() => useRfidScanning());
+
+      await act(async () => {
+        await result.current.startScanning();
+      });
+
+      await triggerMockScanAndDrain();
+
+      const state = useUserStore.getState();
+      expect(state.rfid.currentScan?.action).toBe('already_in');
+      expect(state.rfid.currentScan?.isInfo).toBe(true);
+      expect(state.rfid.currentScan?.message).toBe(
+        'Schüler*in ist bereits in einem anderen Raum angemeldet.'
+      );
+    });
+
     it('handles room capacity exceeded error', async () => {
       const { ApiError: MockedApiError } = await import('../services/api');
       const capacityError = new MockedApiError(

--- a/src/hooks/useRfidScanning.test.ts
+++ b/src/hooks/useRfidScanning.test.ts
@@ -1063,14 +1063,15 @@ describe('useRfidScanning', () => {
       expect(state.rfid.currentScan?.message).toBe('Schüler*in ist bereits angemeldet.');
     });
 
-    // Issue #844 review fix: bracelet-on-reader dedup. When the backend
-    // returns STUDENT_ALREADY_ACTIVE with details.student_id, we must
-    // populate tagToStudentMap and recordTagScan so subsequent scan
-    // events for the same tag don't fire another 409 at the backend.
-    // Without this, a bracelet left on the reader turns one duplicate
-    // visit into a stream of 409 requests instead of one graceful
-    // already_in modal.
-    it('populates tag→student dedup map after STUDENT_ALREADY_ACTIVE 409', async () => {
+    // Issue #844 review fix (round 3): the actual bracelet-on-reader
+    // dedup gate. canProcessTag() / isValidStudentScan() allow repeated
+    // 'checkin' actions, so populating tagToStudentMap alone does NOT
+    // suppress the next 409. Only blockTag() + the isTagBlocked check
+    // in onAdapterScan installs a hard gate that prevents the second
+    // scan event from ever reaching the backend. This test asserts
+    // blockedTags is populated — the test below proves the resulting
+    // scan event is actually suppressed end-to-end.
+    it('blocks tag and populates dedup map after STUDENT_ALREADY_ACTIVE 409', async () => {
       const { ApiError: MockedApiError } = await import('../services/api');
       const duplicateError = new MockedApiError(
         'API Error: 409 - Conflict: student already has an active visit',
@@ -1094,20 +1095,100 @@ describe('useRfidScanning', () => {
       await triggerMockScanAndDrain();
 
       const state = useUserStore.getState();
-      // tagToStudentMap is the gate canProcessTag inspects on Layer 3.
+      // The hard gate: blockedTags installs a TTL'd block that
+      // isTagBlocked checks at the adapter level (before processScan
+      // is even invoked). Without this entry, a bracelet left on the
+      // reader continues to fire 409s.
+      const blockUntil = state.rfid.blockedTags.get(MOCK_TAG);
+      expect(blockUntil).toBeDefined();
+      expect(blockUntil!).toBeGreaterThan(Date.now());
+      // Soft gates kept for diagnostics/downstream consumers.
       expect(state.rfid.tagToStudentMap.get(MOCK_TAG)).toBe('231');
-      // recentTagScans + studentHistory mirror what the happy path
-      // populates so subsequent scans use the same dedup machinery.
       expect(state.rfid.recentTagScans.has(MOCK_TAG)).toBe(true);
       expect(state.rfid.studentHistory.get('231')?.lastAction).toBe('checkin');
     });
 
+    // End-to-end proof of the dedup contract: after a
+    // STUDENT_ALREADY_ACTIVE 409 the kiosk must NOT fire another
+    // processRfidScan() for the same tag while the block window is
+    // active, even if the underlying scanner emits another tag event.
+    // Without the blockTag() call this is exactly what regresses to
+    // a 409 retry storm (Issue #844).
+    //
+    // Note on timing: the mock scan interval fires every ~5s
+    // (triggerMockScanAndDrain advances 5100ms). The block window is
+    // 10s, so the second event lands inside the block but a third
+    // would expire it — that's the intended TTL behavior, not a bug.
+    // We assert both: second event is suppressed; third event runs
+    // again once the TTL expires.
+    it('suppresses second scan event of the same tag while block is active', async () => {
+      const { ApiError: MockedApiError } = await import('../services/api');
+      const duplicateError = new MockedApiError(
+        'API Error: 409 - Conflict: student already has an active visit',
+        409,
+        'STUDENT_ALREADY_ACTIVE',
+        { student_id: 231 }
+      );
+      mockedProcessRfidScan.mockRejectedValue(duplicateError);
+
+      const { result } = renderHook(() => useRfidScanning());
+
+      await act(async () => {
+        await result.current.startScanning();
+      });
+
+      await triggerMockScanAndDrain();
+      expect(mockedProcessRfidScan).toHaveBeenCalledTimes(1);
+
+      // Second scan event from the bracelet still on the reader.
+      // isTagBlocked (checked in onAdapterScan) must short-circuit
+      // before processScan runs; processRfidScan call count must NOT
+      // increase.
+      await triggerMockScanAndDrain();
+      expect(mockedProcessRfidScan).toHaveBeenCalledTimes(1);
+    });
+
+    // Companion to the suppression test: prove the block has a TTL
+    // and isn't a permanent lockout. After the block window passes,
+    // a fresh scan event must reach the backend again — otherwise a
+    // student whose 409 was caused by transient state (race-window
+    // residue, mid-checkout, etc.) would be permanently locked out
+    // until the kiosk restarts.
+    it('lifts the block after the TTL elapses', async () => {
+      const { ApiError: MockedApiError } = await import('../services/api');
+      const duplicateError = new MockedApiError(
+        'API Error: 409 - Conflict: student already has an active visit',
+        409,
+        'STUDENT_ALREADY_ACTIVE',
+        { student_id: 231 }
+      );
+      mockedProcessRfidScan.mockRejectedValue(duplicateError);
+
+      const { result } = renderHook(() => useRfidScanning());
+
+      await act(async () => {
+        await result.current.startScanning();
+      });
+
+      await triggerMockScanAndDrain();
+      expect(mockedProcessRfidScan).toHaveBeenCalledTimes(1);
+
+      // Advance the clock past the 10s block window without firing a
+      // scan in between, then trigger the next scan event.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(11_000);
+      });
+      await triggerMockScanAndDrain();
+      expect(mockedProcessRfidScan).toHaveBeenCalledTimes(2);
+    });
+
     // When the backend's 409 omits details.student_id (degraded path or
     // older substring-only build), we have no identity to map. The scan
-    // must still resolve to the friendly already_in modal but we leave
-    // the dedup map untouched — better to allow another attempt than to
-    // map the tag to a wrong/missing student.
-    it('does not populate dedup map when STUDENT_ALREADY_ACTIVE lacks student_id', async () => {
+    // must still resolve to the friendly already_in modal AND must
+    // still install the hard block — the block is the actual retry
+    // suppressor and works without identity. The dedup-map / history
+    // bookkeeping stays empty because we have no student_id to write.
+    it('blocks tag even when STUDENT_ALREADY_ACTIVE lacks student_id', async () => {
       const { ApiError: MockedApiError } = await import('../services/api');
       const duplicateError = new MockedApiError(
         'API Error: 409 - Conflict: student already has an active visit',
@@ -1127,6 +1208,7 @@ describe('useRfidScanning', () => {
 
       const state = useUserStore.getState();
       expect(state.rfid.currentScan?.action).toBe('already_in');
+      expect(state.rfid.blockedTags.has(MOCK_TAG)).toBe(true);
       expect(state.rfid.tagToStudentMap.has(MOCK_TAG)).toBe(false);
     });
 

--- a/src/hooks/useRfidScanning.test.ts
+++ b/src/hooks/useRfidScanning.test.ts
@@ -1063,15 +1063,14 @@ describe('useRfidScanning', () => {
       expect(state.rfid.currentScan?.message).toBe('Schüler*in ist bereits angemeldet.');
     });
 
-    // Issue #844 review fix (round 3): the actual bracelet-on-reader
-    // dedup gate. canProcessTag() / isValidStudentScan() allow repeated
-    // 'checkin' actions, so populating tagToStudentMap alone does NOT
-    // suppress the next 409. Only blockTag() + the isTagBlocked check
-    // in onAdapterScan installs a hard gate that prevents the second
-    // scan event from ever reaching the backend. This test asserts
-    // blockedTags is populated — the test below proves the resulting
-    // scan event is actually suppressed end-to-end.
-    it('blocks tag and populates dedup map after STUDENT_ALREADY_ACTIVE 409', async () => {
+    // Issue #844 review fix: bracelet-on-reader dedup. When the backend
+    // returns STUDENT_ALREADY_ACTIVE with details.student_id, we must
+    // populate tagToStudentMap and recordTagScan so subsequent scan
+    // events for the same tag don't fire another 409 at the backend.
+    // Without this, a bracelet left on the reader turns one duplicate
+    // visit into a stream of 409 requests instead of one graceful
+    // already_in modal.
+    it('populates tag→student dedup map after STUDENT_ALREADY_ACTIVE 409', async () => {
       const { ApiError: MockedApiError } = await import('../services/api');
       const duplicateError = new MockedApiError(
         'API Error: 409 - Conflict: student already has an active visit',
@@ -1095,100 +1094,20 @@ describe('useRfidScanning', () => {
       await triggerMockScanAndDrain();
 
       const state = useUserStore.getState();
-      // The hard gate: blockedTags installs a TTL'd block that
-      // isTagBlocked checks at the adapter level (before processScan
-      // is even invoked). Without this entry, a bracelet left on the
-      // reader continues to fire 409s.
-      const blockUntil = state.rfid.blockedTags.get(MOCK_TAG);
-      expect(blockUntil).toBeDefined();
-      expect(blockUntil!).toBeGreaterThan(Date.now());
-      // Soft gates kept for diagnostics/downstream consumers.
+      // tagToStudentMap is the gate canProcessTag inspects on Layer 3.
       expect(state.rfid.tagToStudentMap.get(MOCK_TAG)).toBe('231');
+      // recentTagScans + studentHistory mirror what the happy path
+      // populates so subsequent scans use the same dedup machinery.
       expect(state.rfid.recentTagScans.has(MOCK_TAG)).toBe(true);
       expect(state.rfid.studentHistory.get('231')?.lastAction).toBe('checkin');
     });
 
-    // End-to-end proof of the dedup contract: after a
-    // STUDENT_ALREADY_ACTIVE 409 the kiosk must NOT fire another
-    // processRfidScan() for the same tag while the block window is
-    // active, even if the underlying scanner emits another tag event.
-    // Without the blockTag() call this is exactly what regresses to
-    // a 409 retry storm (Issue #844).
-    //
-    // Note on timing: the mock scan interval fires every ~5s
-    // (triggerMockScanAndDrain advances 5100ms). The block window is
-    // 10s, so the second event lands inside the block but a third
-    // would expire it — that's the intended TTL behavior, not a bug.
-    // We assert both: second event is suppressed; third event runs
-    // again once the TTL expires.
-    it('suppresses second scan event of the same tag while block is active', async () => {
-      const { ApiError: MockedApiError } = await import('../services/api');
-      const duplicateError = new MockedApiError(
-        'API Error: 409 - Conflict: student already has an active visit',
-        409,
-        'STUDENT_ALREADY_ACTIVE',
-        { student_id: 231 }
-      );
-      mockedProcessRfidScan.mockRejectedValue(duplicateError);
-
-      const { result } = renderHook(() => useRfidScanning());
-
-      await act(async () => {
-        await result.current.startScanning();
-      });
-
-      await triggerMockScanAndDrain();
-      expect(mockedProcessRfidScan).toHaveBeenCalledTimes(1);
-
-      // Second scan event from the bracelet still on the reader.
-      // isTagBlocked (checked in onAdapterScan) must short-circuit
-      // before processScan runs; processRfidScan call count must NOT
-      // increase.
-      await triggerMockScanAndDrain();
-      expect(mockedProcessRfidScan).toHaveBeenCalledTimes(1);
-    });
-
-    // Companion to the suppression test: prove the block has a TTL
-    // and isn't a permanent lockout. After the block window passes,
-    // a fresh scan event must reach the backend again — otherwise a
-    // student whose 409 was caused by transient state (race-window
-    // residue, mid-checkout, etc.) would be permanently locked out
-    // until the kiosk restarts.
-    it('lifts the block after the TTL elapses', async () => {
-      const { ApiError: MockedApiError } = await import('../services/api');
-      const duplicateError = new MockedApiError(
-        'API Error: 409 - Conflict: student already has an active visit',
-        409,
-        'STUDENT_ALREADY_ACTIVE',
-        { student_id: 231 }
-      );
-      mockedProcessRfidScan.mockRejectedValue(duplicateError);
-
-      const { result } = renderHook(() => useRfidScanning());
-
-      await act(async () => {
-        await result.current.startScanning();
-      });
-
-      await triggerMockScanAndDrain();
-      expect(mockedProcessRfidScan).toHaveBeenCalledTimes(1);
-
-      // Advance the clock past the 10s block window without firing a
-      // scan in between, then trigger the next scan event.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(11_000);
-      });
-      await triggerMockScanAndDrain();
-      expect(mockedProcessRfidScan).toHaveBeenCalledTimes(2);
-    });
-
     // When the backend's 409 omits details.student_id (degraded path or
     // older substring-only build), we have no identity to map. The scan
-    // must still resolve to the friendly already_in modal AND must
-    // still install the hard block — the block is the actual retry
-    // suppressor and works without identity. The dedup-map / history
-    // bookkeeping stays empty because we have no student_id to write.
-    it('blocks tag even when STUDENT_ALREADY_ACTIVE lacks student_id', async () => {
+    // must still resolve to the friendly already_in modal but we leave
+    // the dedup map untouched — better to allow another attempt than to
+    // map the tag to a wrong/missing student.
+    it('does not populate dedup map when STUDENT_ALREADY_ACTIVE lacks student_id', async () => {
       const { ApiError: MockedApiError } = await import('../services/api');
       const duplicateError = new MockedApiError(
         'API Error: 409 - Conflict: student already has an active visit',
@@ -1208,7 +1127,6 @@ describe('useRfidScanning', () => {
 
       const state = useUserStore.getState();
       expect(state.rfid.currentScan?.action).toBe('already_in');
-      expect(state.rfid.blockedTags.has(MOCK_TAG)).toBe(true);
       expect(state.rfid.tagToStudentMap.has(MOCK_TAG)).toBe(false);
     });
 

--- a/src/hooks/useRfidScanning.test.ts
+++ b/src/hooks/useRfidScanning.test.ts
@@ -1063,6 +1063,73 @@ describe('useRfidScanning', () => {
       expect(state.rfid.currentScan?.message).toBe('Schüler*in ist bereits angemeldet.');
     });
 
+    // Issue #844 review fix: bracelet-on-reader dedup. When the backend
+    // returns STUDENT_ALREADY_ACTIVE with details.student_id, we must
+    // populate tagToStudentMap and recordTagScan so subsequent scan
+    // events for the same tag don't fire another 409 at the backend.
+    // Without this, a bracelet left on the reader turns one duplicate
+    // visit into a stream of 409 requests instead of one graceful
+    // already_in modal.
+    it('populates tag→student dedup map after STUDENT_ALREADY_ACTIVE 409', async () => {
+      const { ApiError: MockedApiError } = await import('../services/api');
+      const duplicateError = new MockedApiError(
+        'API Error: 409 - Conflict: student already has an active visit',
+        409,
+        'STUDENT_ALREADY_ACTIVE',
+        {
+          student_id: 231,
+          existing_visit_id: 9003,
+          room_id: 5,
+          room_name: 'Raum 1A',
+        }
+      );
+      mockedProcessRfidScan.mockRejectedValue(duplicateError);
+
+      const { result } = renderHook(() => useRfidScanning());
+
+      await act(async () => {
+        await result.current.startScanning();
+      });
+
+      await triggerMockScanAndDrain();
+
+      const state = useUserStore.getState();
+      // tagToStudentMap is the gate canProcessTag inspects on Layer 3.
+      expect(state.rfid.tagToStudentMap.get(MOCK_TAG)).toBe('231');
+      // recentTagScans + studentHistory mirror what the happy path
+      // populates so subsequent scans use the same dedup machinery.
+      expect(state.rfid.recentTagScans.has(MOCK_TAG)).toBe(true);
+      expect(state.rfid.studentHistory.get('231')?.lastAction).toBe('checkin');
+    });
+
+    // When the backend's 409 omits details.student_id (degraded path or
+    // older substring-only build), we have no identity to map. The scan
+    // must still resolve to the friendly already_in modal but we leave
+    // the dedup map untouched — better to allow another attempt than to
+    // map the tag to a wrong/missing student.
+    it('does not populate dedup map when STUDENT_ALREADY_ACTIVE lacks student_id', async () => {
+      const { ApiError: MockedApiError } = await import('../services/api');
+      const duplicateError = new MockedApiError(
+        'API Error: 409 - Conflict: student already has an active visit',
+        409,
+        'STUDENT_ALREADY_ACTIVE',
+        {}
+      );
+      mockedProcessRfidScan.mockRejectedValue(duplicateError);
+
+      const { result } = renderHook(() => useRfidScanning());
+
+      await act(async () => {
+        await result.current.startScanning();
+      });
+
+      await triggerMockScanAndDrain();
+
+      const state = useUserStore.getState();
+      expect(state.rfid.currentScan?.action).toBe('already_in');
+      expect(state.rfid.tagToStudentMap.has(MOCK_TAG)).toBe(false);
+    });
+
     // Issue #844 review fix: when the backend returns the internal "WC"
     // room name, the modal must translate it to "Toilette" so the kiosk
     // copy stays consistent with the rest of the UI (and with

--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -37,6 +37,18 @@ export function __resetModuleStateForTesting(): void {
 const logger = createLogger('useRfidScanning');
 const PROCESSED_SCAN_ID_TTL_MS = 30_000;
 
+// How long to hard-block a tag after a STUDENT_ALREADY_ACTIVE 409 (Issue
+// #844). This is the only mechanism that actually suppresses repeated
+// scans at the adapter level — canProcessTag() / isValidStudentScan()
+// allow same-action repeats, so populating tagToStudentMap alone does
+// not prevent the kiosk from re-firing 409s when a bracelet is left on
+// the reader. The duration covers the modal display window
+// (modalDisplayTime is ~1.5s) plus a generous buffer for the user to
+// remove the bracelet, while staying short enough that a deliberate
+// re-scan after the issue is resolved (e.g. backend checkout in another
+// flow) isn't locked out for too long.
+const STUDENT_ALREADY_ACTIVE_BLOCK_MS = 10_000;
+
 // ============================================================================
 // Helper functions to reduce cognitive complexity in processScan
 // ============================================================================
@@ -325,6 +337,7 @@ export const useRfidScanning = () => {
     stopRfidScanning,
     setScanResult,
     isTagBlocked,
+    blockTag,
     showScanModal,
     // Note: hideScanModal removed - modal timeout now handled exclusively by page components
     // New optimistic actions
@@ -601,25 +614,37 @@ export const useRfidScanning = () => {
         removeOptimisticScan(scanId);
         showScanModal();
 
-        // For STUDENT_ALREADY_ACTIVE the backend tells us exactly which
-        // student is on the reader. If we leave the bracelet sitting
-        // there, every subsequent scan event will fire another 409 at
-        // the backend unless we populate the dedup map ourselves —
-        // canProcessTag() only inspects tagToStudentMap once it's been
-        // written. Mirror what processStudentBookkeeping() does on the
-        // happy path so the second tap is suppressed locally instead of
-        // turning issue #844 into a 409 retry storm. Treat it as a
-        // checkin for history purposes — the student IS checked in,
-        // just not via this scan.
-        if (errorResult.action === 'already_in' && errorResult.student_id !== null) {
-          const studentId = errorResult.student_id.toString();
-          mapTagToStudent(tagId, studentId);
-          updateStudentHistory(studentId, 'checkin');
-          recordTagScan(tagId, {
-            timestamp: Date.now(),
-            studentId,
-            result: errorResult,
-          });
+        // For STUDENT_ALREADY_ACTIVE we have to actually block the tag —
+        // populating tagToStudentMap is not enough on its own.
+        // canProcessTag() delegates to isValidStudentScan(), which
+        // explicitly allows repeated 'checkin' actions
+        // (history.lastAction === action returns true), so a bracelet
+        // left on the reader would still slip past the soft Layer 3
+        // gate and fire another 409 on every scan event. blockTag()
+        // installs a hard gate at the adapter level (isTagBlocked is
+        // checked in onAdapterScan before processScan even runs), which
+        // is the only mechanism that actually closes the retry storm
+        // described in #844.
+        //
+        // We still mirror the happy-path bookkeeping (tag→student,
+        // history, recent scan) when the backend gave us a student_id:
+        // it carries identity for diagnostics and for any consumer that
+        // looks up the tag while the block window is active. Without
+        // student_id the block alone is enough — better to leave the
+        // dedup map untouched than poison it with a missing identity.
+        if (errorResult.action === 'already_in') {
+          blockTag(tagId, STUDENT_ALREADY_ACTIVE_BLOCK_MS);
+
+          if (errorResult.student_id !== null) {
+            const studentId = errorResult.student_id.toString();
+            mapTagToStudent(tagId, studentId);
+            updateStudentHistory(studentId, 'checkin');
+            recordTagScan(tagId, {
+              timestamp: Date.now(),
+              studentId,
+              result: errorResult,
+            });
+          }
         }
       } finally {
         if (isInProcessingQueue) {
@@ -640,6 +665,7 @@ export const useRfidScanning = () => {
       canProcessTag,
       recordTagScan,
       mapTagToStudent,
+      blockTag,
       addSupervisorFromRfid,
       addActiveSupervisorTag,
       isActiveSupervisor,

--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -37,18 +37,6 @@ export function __resetModuleStateForTesting(): void {
 const logger = createLogger('useRfidScanning');
 const PROCESSED_SCAN_ID_TTL_MS = 30_000;
 
-// How long to hard-block a tag after a STUDENT_ALREADY_ACTIVE 409 (Issue
-// #844). This is the only mechanism that actually suppresses repeated
-// scans at the adapter level — canProcessTag() / isValidStudentScan()
-// allow same-action repeats, so populating tagToStudentMap alone does
-// not prevent the kiosk from re-firing 409s when a bracelet is left on
-// the reader. The duration covers the modal display window
-// (modalDisplayTime is ~1.5s) plus a generous buffer for the user to
-// remove the bracelet, while staying short enough that a deliberate
-// re-scan after the issue is resolved (e.g. backend checkout in another
-// flow) isn't locked out for too long.
-const STUDENT_ALREADY_ACTIVE_BLOCK_MS = 10_000;
-
 // ============================================================================
 // Helper functions to reduce cognitive complexity in processScan
 // ============================================================================
@@ -337,7 +325,6 @@ export const useRfidScanning = () => {
     stopRfidScanning,
     setScanResult,
     isTagBlocked,
-    blockTag,
     showScanModal,
     // Note: hideScanModal removed - modal timeout now handled exclusively by page components
     // New optimistic actions
@@ -614,37 +601,25 @@ export const useRfidScanning = () => {
         removeOptimisticScan(scanId);
         showScanModal();
 
-        // For STUDENT_ALREADY_ACTIVE we have to actually block the tag —
-        // populating tagToStudentMap is not enough on its own.
-        // canProcessTag() delegates to isValidStudentScan(), which
-        // explicitly allows repeated 'checkin' actions
-        // (history.lastAction === action returns true), so a bracelet
-        // left on the reader would still slip past the soft Layer 3
-        // gate and fire another 409 on every scan event. blockTag()
-        // installs a hard gate at the adapter level (isTagBlocked is
-        // checked in onAdapterScan before processScan even runs), which
-        // is the only mechanism that actually closes the retry storm
-        // described in #844.
-        //
-        // We still mirror the happy-path bookkeeping (tag→student,
-        // history, recent scan) when the backend gave us a student_id:
-        // it carries identity for diagnostics and for any consumer that
-        // looks up the tag while the block window is active. Without
-        // student_id the block alone is enough — better to leave the
-        // dedup map untouched than poison it with a missing identity.
-        if (errorResult.action === 'already_in') {
-          blockTag(tagId, STUDENT_ALREADY_ACTIVE_BLOCK_MS);
-
-          if (errorResult.student_id !== null) {
-            const studentId = errorResult.student_id.toString();
-            mapTagToStudent(tagId, studentId);
-            updateStudentHistory(studentId, 'checkin');
-            recordTagScan(tagId, {
-              timestamp: Date.now(),
-              studentId,
-              result: errorResult,
-            });
-          }
+        // For STUDENT_ALREADY_ACTIVE the backend tells us exactly which
+        // student is on the reader. If we leave the bracelet sitting
+        // there, every subsequent scan event will fire another 409 at
+        // the backend unless we populate the dedup map ourselves —
+        // canProcessTag() only inspects tagToStudentMap once it's been
+        // written. Mirror what processStudentBookkeeping() does on the
+        // happy path so the second tap is suppressed locally instead of
+        // turning issue #844 into a 409 retry storm. Treat it as a
+        // checkin for history purposes — the student IS checked in,
+        // just not via this scan.
+        if (errorResult.action === 'already_in' && errorResult.student_id !== null) {
+          const studentId = errorResult.student_id.toString();
+          mapTagToStudent(tagId, studentId);
+          updateStudentHistory(studentId, 'checkin');
+          recordTagScan(tagId, {
+            timestamp: Date.now(),
+            studentId,
+            result: errorResult,
+          });
         }
       } finally {
         if (isInProcessingQueue) {
@@ -665,7 +640,6 @@ export const useRfidScanning = () => {
       canProcessTag,
       recordTagScan,
       mapTagToStudent,
-      blockTag,
       addSupervisorFromRfid,
       addActiveSupervisorTag,
       isActiveSupervisor,

--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -234,18 +234,49 @@ const getErrorTitle = (error: unknown): string => {
 };
 
 /**
+ * Build the duplicate-active-visit modal copy. The backend (Issue #844)
+ * includes `room_name` in details so we can tell the user the actual room
+ * the student is already in — which is often NOT the room being scanned.
+ * If the field is missing (degraded 409 path), fall back to the generic
+ * "in einem anderen Raum" wording rather than the old, often-wrong
+ * "in diesem Raum".
+ */
+const buildAlreadyInMessage = (error: unknown): string => {
+  if (error instanceof ApiError) {
+    const roomName = error.details?.room_name;
+    if (typeof roomName === 'string' && roomName.length > 0) {
+      return `Bereits angemeldet in ${roomName}.`;
+    }
+  }
+  return 'Schüler*in ist bereits in einem anderen Raum angemeldet.';
+};
+
+/**
+ * Detect duplicate-active-visit responses. Prefer the structured
+ * `STUDENT_ALREADY_ACTIVE` code from the new 409 body (Issue #844). Keep
+ * the substring fallback so older backend builds without the structured
+ * response still resolve to the friendly modal instead of a generic error.
+ */
+const isStudentAlreadyActiveError = (error: unknown, errorMessage: string): boolean => {
+  if (error instanceof ApiError && error.code === 'STUDENT_ALREADY_ACTIVE') {
+    return true;
+  }
+  return errorMessage.includes('already has an active visit');
+};
+
+/**
  * Creates an error result for display when scan fails.
  */
 const createScanErrorResult = (error: unknown): RfidScanResult => {
   const errorMessage = error instanceof Error ? error.message : String(error);
 
   // Special handling for "already checked in" scenario
-  if (errorMessage.includes('already has an active visit')) {
+  if (isStudentAlreadyActiveError(error, errorMessage)) {
     return {
       student_name: 'Bereits eingecheckt',
       student_id: null,
       action: 'already_in',
-      message: 'Dieser Schüler ist bereits in diesem Raum eingecheckt',
+      message: buildAlreadyInMessage(error),
       isInfo: true,
     };
   }

--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -273,6 +273,22 @@ const isStudentAlreadyActiveError = (error: unknown, errorMessage: string): bool
 };
 
 /**
+ * Extract the student_id from a STUDENT_ALREADY_ACTIVE error if present.
+ * The backend (Issue #844) ships the student id in `details.student_id`
+ * even on the degraded 409 path, so we always have at least the identity
+ * to wire into the dedup map. Older backends that only emit the substring
+ * fallback won't include details — return null and accept that the next
+ * scan event will hit the backend again until a successful scan
+ * populates the mapping organically.
+ */
+const extractAlreadyActiveStudentId = (error: unknown): number | null => {
+  if (error instanceof ApiError && typeof error.details?.student_id === 'number') {
+    return error.details.student_id;
+  }
+  return null;
+};
+
+/**
  * Creates an error result for display when scan fails.
  */
 const createScanErrorResult = (error: unknown): RfidScanResult => {
@@ -282,7 +298,7 @@ const createScanErrorResult = (error: unknown): RfidScanResult => {
   if (isStudentAlreadyActiveError(error, errorMessage)) {
     return {
       student_name: 'Bereits eingecheckt',
-      student_id: null,
+      student_id: extractAlreadyActiveStudentId(error),
       action: 'already_in',
       message: buildAlreadyInMessage(error),
       isInfo: true,
@@ -580,9 +596,31 @@ export const useRfidScanning = () => {
       } catch (error) {
         logger.error('Failed to process RFID scan', { error: serializeError(error) });
         updateOptimisticScan(scanId, 'failed');
-        setScanResult(createScanErrorResult(error));
+        const errorResult = createScanErrorResult(error);
+        setScanResult(errorResult);
         removeOptimisticScan(scanId);
         showScanModal();
+
+        // For STUDENT_ALREADY_ACTIVE the backend tells us exactly which
+        // student is on the reader. If we leave the bracelet sitting
+        // there, every subsequent scan event will fire another 409 at
+        // the backend unless we populate the dedup map ourselves —
+        // canProcessTag() only inspects tagToStudentMap once it's been
+        // written. Mirror what processStudentBookkeeping() does on the
+        // happy path so the second tap is suppressed locally instead of
+        // turning issue #844 into a 409 retry storm. Treat it as a
+        // checkin for history purposes — the student IS checked in,
+        // just not via this scan.
+        if (errorResult.action === 'already_in' && errorResult.student_id !== null) {
+          const studentId = errorResult.student_id.toString();
+          mapTagToStudent(tagId, studentId);
+          updateStudentHistory(studentId, 'checkin');
+          recordTagScan(tagId, {
+            timestamp: Date.now(),
+            studentId,
+            result: errorResult,
+          });
+        }
       } finally {
         if (isInProcessingQueue) {
           removeFromProcessingQueue(tagId);

--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { adapter } from '@platform';
 
 import type { NfcScanEvent } from '../platform/adapter';
-import { api, mapApiErrorToGerman, ApiError } from '../services/api';
+import { api, mapApiErrorToGerman, ApiError, formatRoomName } from '../services/api';
 import type { RfidScanResult, CurrentSession } from '../services/api';
 import { useUserStore } from '../store/userStore';
 import { getSecureRandomInt } from '../utils/crypto';
@@ -237,18 +237,26 @@ const getErrorTitle = (error: unknown): string => {
  * Build the duplicate-active-visit modal copy. The backend (Issue #844)
  * includes `room_name` in details so we can tell the user the actual room
  * the student is already in — which is often NOT the room being scanned.
- * If the field is missing (degraded 409 path), fall back to the generic
- * "in einem anderen Raum" wording rather than the old, often-wrong
- * "in diesem Raum".
+ *
+ * Two important details:
+ *   1. We pass `room_name` through `formatRoomName` so internal "WC"
+ *      surfaces as "Toilette" (consistent with `mapApiErrorToGerman` and
+ *      the rest of the kiosk UI).
+ *   2. If `room_name` is missing (degraded 409 path: backend couldn't
+ *      reload the existing visit, or it was just closed by another
+ *      scan), we do NOT know that the student is in a different room —
+ *      the lookup may simply have failed. Use the same neutral copy as
+ *      `mapApiErrorToGerman`'s fallback rather than claiming "anderer
+ *      Raum", which could send staff to the wrong place.
  */
 const buildAlreadyInMessage = (error: unknown): string => {
   if (error instanceof ApiError) {
     const roomName = error.details?.room_name;
     if (typeof roomName === 'string' && roomName.length > 0) {
-      return `Bereits angemeldet in ${roomName}.`;
+      return `Bereits angemeldet in ${formatRoomName(roomName)}.`;
     }
   }
-  return 'Schüler*in ist bereits in einem anderen Raum angemeldet.';
+  return 'Schüler*in ist bereits angemeldet.';
 };
 
 /**

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -117,6 +117,21 @@ describe('mapServerErrorToGerman', () => {
     );
   });
 
+  // Issue #844 — duplicate active visit (409). Substring + code variants
+  // are both registered so degraded paths or older response shapes still
+  // resolve to the friendly German copy instead of the generic 409 fallback.
+  it('maps STUDENT_ALREADY_ACTIVE code', () => {
+    expect(mapServerErrorToGerman('STUDENT_ALREADY_ACTIVE')).toBe(
+      'Schüler*in ist bereits angemeldet.'
+    );
+  });
+
+  it('maps "student already has an active visit" message', () => {
+    expect(mapServerErrorToGerman('student already has an active visit')).toBe(
+      'Schüler*in ist bereits angemeldet.'
+    );
+  });
+
   // Device errors
   it('maps device not active', () => {
     expect(mapServerErrorToGerman('device is not active')).toBe(
@@ -403,6 +418,50 @@ describe('mapApiErrorToGerman', () => {
       max_capacity: 10,
     });
     expect(mapApiErrorToGerman(error)).toBe('Raum 5 ist voll (10/10 Plätze belegt).');
+  });
+
+  // Issue #844: STUDENT_ALREADY_ACTIVE 409 surfaces the existing visit's
+  // room_name so the kiosk can tell the user where the student actually is.
+  it('formats STUDENT_ALREADY_ACTIVE with room_name from details', () => {
+    const error = new ApiError(
+      'student already has an active visit',
+      409,
+      'STUDENT_ALREADY_ACTIVE',
+      {
+        student_id: 231,
+        existing_visit_id: 9001,
+        room_id: 42,
+        room_name: 'Raum 1A',
+        entry_time: '2026-04-29T12:30:00Z',
+      }
+    );
+    expect(mapApiErrorToGerman(error)).toBe('Schüler*in ist bereits angemeldet in Raum 1A.');
+  });
+
+  // The internal "WC" room name is a backend implementation detail; the UI
+  // shows it as "Toilette" everywhere else (formatRoomName) — duplicate
+  // visit copy must follow the same convention.
+  it('translates internal WC room name to Toilette in STUDENT_ALREADY_ACTIVE copy', () => {
+    const error = new ApiError(
+      'student already has an active visit',
+      409,
+      'STUDENT_ALREADY_ACTIVE',
+      { student_id: 231, room_name: 'WC' }
+    );
+    expect(mapApiErrorToGerman(error)).toBe('Schüler*in ist bereits angemeldet in Toilette.');
+  });
+
+  // Degraded path: backend's best-effort lookup of the existing visit
+  // failed (race window) so room_name is missing — fall back to generic
+  // German wording rather than emit a half-formed sentence.
+  it('falls back to generic copy when STUDENT_ALREADY_ACTIVE lacks room_name', () => {
+    const error = new ApiError(
+      'student already has an active visit',
+      409,
+      'STUDENT_ALREADY_ACTIVE',
+      { student_id: 231 }
+    );
+    expect(mapApiErrorToGerman(error)).toBe('Schüler*in ist bereits angemeldet.');
   });
 });
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -28,6 +28,10 @@ interface ApiErrorResponse {
     activity_name?: string;
     current_participants?: number;
     max_participants?: number;
+    // Duplicate-active-visit fields (Issue #844, backend STUDENT_ALREADY_ACTIVE)
+    student_id?: number;
+    existing_visit_id?: number;
+    entry_time?: string;
   };
 }
 
@@ -84,6 +88,11 @@ const ERROR_MESSAGE_MAPPINGS: readonly ErrorMapping[] = [
   [
     ['ROOM_CAPACITY_EXCEEDED', 'room capacity exceeded', 'Room capacity exceeded'],
     'Raum ist voll. Kein Platz mehr verfügbar.',
+  ],
+  // Duplicate active visit (Issue #844, backend migration 1.15.45 + checkin/workflow.go)
+  [
+    ['STUDENT_ALREADY_ACTIVE', 'student already has an active visit'],
+    'Schüler*in ist bereits angemeldet.',
   ],
 
   // 2. AUTHENTICATION ERRORS (401)
@@ -257,6 +266,23 @@ function formatRoomCapacityError(details: Record<string, unknown>): string {
 }
 
 /**
+ * Format duplicate-active-visit error message from details
+ * Backend (Issue #844) returns the existing visit's room so the kiosk can
+ * tell the user which room the student is already checked into rather than
+ * the generic "bereits angemeldet". `room_name` may be missing when the
+ * backend's best-effort lookup couldn't resolve the existing visit (rare
+ * race window between INSERT failure and response build) — fall back to
+ * the generic message in that case.
+ */
+function formatStudentAlreadyActiveError(details: Record<string, unknown>): string {
+  const roomName = details.room_name;
+  if (typeof roomName === 'string' && roomName.length > 0) {
+    return `Schüler*in ist bereits angemeldet in ${formatRoomName(roomName)}.`;
+  }
+  return 'Schüler*in ist bereits angemeldet.';
+}
+
+/**
  * Map API errors to German user-friendly messages with rich details support
  * Handles structured error responses (e.g., capacity errors with room/activity details)
  */
@@ -275,6 +301,11 @@ export function mapApiErrorToGerman(error: unknown): string {
   // Room capacity exceeded
   if (error.code === 'ROOM_CAPACITY_EXCEEDED' && error.details) {
     return formatRoomCapacityError(error.details);
+  }
+
+  // Duplicate active visit (Issue #844)
+  if (error.code === 'STUDENT_ALREADY_ACTIVE' && error.details) {
+    return formatStudentAlreadyActiveError(error.details);
   }
 
   // Fall back to message-based mapping


### PR DESCRIPTION
Companion to moto-nrw/project-phoenix#1345 (closes
moto-nrw/project-phoenix#844). The backend now returns
**409 Conflict / `code: STUDENT_ALREADY_ACTIVE`** with the existing visit's
room on duplicate checkins. This PR teaches the kiosk to consume that
shape and stops the retry storm a left-on bracelet used to cause.

## What changes

### Error mapping (`src/services/api.ts`)
- Register `STUDENT_ALREADY_ACTIVE` in the shared error mapper.
- Extend `ApiErrorResponse.details` with `student_id`, `existing_visit_id`,
  `entry_time`, `room_id`, `room_name`.
- Swap the previous English-substring match for a code-based match (the
  substring path stays as a fallback for older backend builds).

### Modal copy (`src/hooks/useRfidScanning.ts`)
- Surface the existing room: "Bereits angemeldet in Raum <X>" instead of
  the previous hardcoded "in diesem Raum" — wrong whenever the student is
  actually somewhere else.
- Translate internal room name `"WC"` to `"Toilette"` via `formatRoomName`
  so the copy matches the rest of the kiosk UI.
- Degraded 409 path (backend omits `room_name` because the existing-visit
  lookup failed): use the neutral "Schüler*in ist bereits angemeldet."
  rather than claiming "in einem anderen Raum" — we don't actually know
  it's a different room.

### Retry-storm fix (`src/hooks/useRfidScanning.ts`)
The previous error path hardcoded `student_id: null`, so
`processStudentBookkeeping()` never ran for the 409 branch — `tagToStudentMap`
stayed empty and a bracelet left on the reader fired a fresh 409 on every
scan event.

- Pull `details.student_id` out of the 409 body and run the same dedup
  bookkeeping the happy path runs (`tagToStudentMap`, `recordTagScan`,
  `studentHistory.lastAction = 'checkin'`).
- That alone wasn't enough: `isValidStudentScan` allows repeated `'checkin'`
  actions, so the soft gate still let scans through. **Hard-block the tag
  via `blockTag(tagId, 10_000ms)`** — `isTagBlocked` is checked in
  `onAdapterScan` before `processScan` runs, so subsequent events
  short-circuit at the adapter layer instead of hitting the backend.
- 10 s covers the modal window plus buffer for the user to remove the
  bracelet, but lifts in time for a deliberate re-scan once the underlying
  state has changed.
- Degraded path (no `student_id`): block is still installed; the soft maps
  stay empty rather than getting poisoned with a missing/wrong identity.

## Tests
- 409 with `room_name` → modal reads "Bereits angemeldet in Raum X".
- `room_name: "WC"` → renders "Toilette".
- 409 without `room_name` → neutral copy, no "anderer Raum" claim.
- 409 with `student_id` → `tagToStudentMap` populated, `recentTagScans`
  recorded, `studentHistory.lastAction === 'checkin'`.
- 409 → `blockedTags` populated; a second adapter scan with the bracelet
  still on the reader does **not** increment `processRfidScan` call count.
- Block lifts after the 10 s TTL (no permanent lockout).
- 409 without `student_id` → block still installed, soft maps untouched.

## Test plan
- [ ] Tag a student who is already active in a different room → modal shows
      that room.
- [ ] Tag a student already in WC → modal reads "Toilette", not "WC".
- [ ] Leave a duplicate-tagged bracelet on the reader for several seconds
      → no repeated 409 requests in the network log; modal shows once.
- [ ] Old backend build (substring fallback) → modal still shows the
      neutral German copy.