### PR TITLE
Add Slack deploy notifications

### DIFF
--- a/.github/actions/notify-deploy-slack/action.yml
+++ b/.github/actions/notify-deploy-slack/action.yml
@@ -1,0 +1,116 @@
+name: Notify Deploy Slack
+description: Send Slack notification for deploy outcomes (success, failure, cancelled) via Incoming Webhook
+
+inputs:
+  webhook_url:
+    description: "Slack Incoming Webhook URL"
+    required: true
+  job_status:
+    description: "GitHub job.status (success, failure, cancelled)"
+    required: true
+  environment:
+    description: "Target environment (staging, production)"
+    required: true
+  exit_code:
+    description: "Exit code from the deploy command. Empty for non-deploy notifications."
+    required: false
+    default: ""
+  run_url:
+    description: "Full URL to the GitHub Actions run"
+    required: true
+  commit_url:
+    description: "Full URL to the commit"
+    required: true
+  sha:
+    description: "Commit SHA (truncated to 7 chars for display)"
+    required: true
+  actor:
+    description: "GitHub actor who triggered the workflow"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        WEBHOOK_URL: ${{ inputs.webhook_url }}
+        JOB_STATUS: ${{ inputs.job_status }}
+        ENV: ${{ inputs.environment }}
+        EXIT_CODE: ${{ inputs.exit_code }}
+        RUN_URL: ${{ inputs.run_url }}
+        COMMIT_URL: ${{ inputs.commit_url }}
+        INPUT_SHA: ${{ inputs.sha }}
+        ACTOR: ${{ inputs.actor }}
+      run: |
+        if [ -z "$WEBHOOK_URL" ]; then
+          echo "::warning::SLACK_DEPLOY_WEBHOOK secret not set, skipping Slack notification"
+          exit 0
+        fi
+
+        SHORT_SHA=$(echo "$INPUT_SHA" | cut -c1-7)
+
+        if [ "$ENV" = "production" ]; then
+          DISPLAY_ENV="Production"
+        else
+          DISPLAY_ENV="$(echo "$ENV" | sed 's/./\U&/')"
+        fi
+
+        # Map job_status to (emoji, headline). Use Unicode emoji so
+        # rendering doesn't depend on Slack's :shortcode: → emoji conversion.
+        if [ "$JOB_STATUS" = "success" ]; then
+          EMOJI="✅"
+          HEADLINE="$DISPLAY_ENV deploy succeeded"
+        elif [ "$JOB_STATUS" = "cancelled" ]; then
+          EMOJI="🚫"
+          HEADLINE="$DISPLAY_ENV deploy cancelled"
+        else
+          EMOJI="❌"
+          HEADLINE="$DISPLAY_ENV deploy failed"
+        fi
+
+        if [ -n "$EXIT_CODE" ] && [ "$EXIT_CODE" != "0" ]; then
+          DETAIL=" · exit $EXIT_CODE"
+        else
+          DETAIL=""
+        fi
+
+        # Build the payload entirely inside jq so newlines and JSON escaping are
+        # handled in one pass. Keep the Slack message intentionally short.
+        # Best-effort: notification failures must never mask the real deploy outcome.
+        if ! PAYLOAD=$(jq -n \
+          --arg emoji "$EMOJI" \
+          --arg headline "$HEADLINE" \
+          --arg commit_url "$COMMIT_URL" \
+          --arg sha "$SHORT_SHA" \
+          --arg actor "$ACTOR" \
+          --arg detail "$DETAIL" \
+          --arg run_url "$RUN_URL" \
+          '{
+            text: "\($emoji) \($headline) — commit \($sha)",
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  type: "mrkdwn",
+                  text: "\($emoji) *\($headline)* · <\($commit_url)|`\($sha)`> by *\($actor)*\($detail) · <\($run_url)|Run>"
+                }
+              }
+            ]
+          }' 2>&1); then
+          echo "::warning::Failed to build Slack payload (non-critical): $PAYLOAD"
+          exit 0
+        fi
+
+        if ! HTTP_RESPONSE=$(curl -sS -o /tmp/slack_response.txt -w "%{http_code}" \
+          -X POST "$WEBHOOK_URL" \
+          -H "Content-Type: application/json" \
+          -d "$PAYLOAD" 2>&1); then
+          echo "::warning::Slack notification request failed (non-critical): $HTTP_RESPONSE"
+          exit 0
+        fi
+
+        if [ "$HTTP_RESPONSE" -ge 200 ] 2>/dev/null && [ "$HTTP_RESPONSE" -lt 300 ] 2>/dev/null; then
+          echo "Slack notification sent (HTTP $HTTP_RESPONSE)"
+        else
+          echo "::warning::Slack notification rejected (HTTP $HTTP_RESPONSE, non-critical): $(cat /tmp/slack_response.txt 2>/dev/null)"
+        fi

--- a/.github/workflows/deploy-gkt.yml
+++ b/.github/workflows/deploy-gkt.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       API_URL: ${{ github.ref == 'refs/heads/main' && vars.GKT_PROD_API_URL || vars.GKT_STAGING_API_URL }}
       DEPLOY_DIR: ${{ github.ref == 'refs/heads/main' && '/var/www/pyreportal' || '/var/www/pyreportal-staging' }}
+      DEPLOY_ENV: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -45,8 +46,35 @@ jobs:
           ssh-keyscan -H ${{ vars.DEPLOY_HOST }} >> ~/.ssh/known_hosts
 
       - name: Deploy
+        id: deploy
         run: |
+          set +e
           rsync -av --delete \
             -e "ssh -i ~/.ssh/deploy_key" \
             dist/ \
             root@${{ vars.DEPLOY_HOST }}:${{ env.DEPLOY_DIR }}/
+          DEPLOY_EXIT=$?
+          set -e
+
+          echo "deploy_exit=$DEPLOY_EXIT" >> "$GITHUB_OUTPUT"
+
+          if [ "$DEPLOY_EXIT" -ne 0 ]; then
+            exit 1
+          fi
+
+      - name: Cleanup secrets
+        if: always()
+        run: rm -f ~/.ssh/deploy_key
+
+      - name: Notify Slack
+        if: always() && steps.deploy.outcome != 'skipped'
+        uses: ./.github/actions/notify-deploy-slack
+        with:
+          webhook_url: ${{ secrets.SLACK_DEPLOY_WEBHOOK }}
+          job_status: ${{ job.status }}
+          environment: ${{ env.DEPLOY_ENV }}
+          exit_code: ${{ steps.deploy.outputs.deploy_exit }}
+          run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          commit_url: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          sha: ${{ github.sha }}
+          actor: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- add a reusable Slack deployment notification composite action
- call it after the GKT deploy step for staging and production
- keep the Slack message compact with status, commit, actor, optional exit code, and run link

## Notes
- `SLACK_DEPLOY_WEBHOOK` is not set yet in `moto-nrw/PyrePortal`; the action will skip with a warning until that repository secret exists.
- The webhook is intentionally best-effort so Slack failures do not mask the deploy result.

## Validation
- `actionlint .github/workflows/deploy-gkt.yml`
- YAML parse check for `.github/actions/notify-deploy-slack/action.yml`
- `jq` payload smoke test
- pre-push hooks: `git-secrets`, `version-sync`, `frontend-knip`, `frontend-check`