### PR TITLE
fix(rooms): accept WC and Toilette as toilet room aliases (#1184)

### DIFF
--- a/src/pages/ActivityScanningPage.test.tsx
+++ b/src/pages/ActivityScanningPage.test.tsx
@@ -659,6 +659,32 @@ describe('ActivityScanningPage', () => {
     });
   });
 
+  it('shows Toilette button when Toilette room alias is found', async () => {
+    mockedApi.getRooms.mockResolvedValueOnce([
+      { id: 89, name: 'Toilette', room_type: 'facility', capacity: 5, is_occupied: false },
+    ]);
+
+    mockRfidHookReturn = {
+      ...mockRfidHookReturn,
+      currentScan: {
+        student_id: 42,
+        student_name: 'Lisa Schmidt',
+        action: 'checked_out',
+        daily_checkout_available: false,
+        scannedTagId: '04:AA:BB:CC:DD:EE:FF',
+      },
+      showModal: true,
+    };
+
+    await act(async () => {
+      renderPage();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Toilette')).toBeInTheDocument();
+    });
+  });
+
   // =======================================================================
   // Raumwechsel click
   // =======================================================================
@@ -805,6 +831,49 @@ describe('ActivityScanningPage', () => {
   it('handles Toilette click success', async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     mockedApi.getRooms.mockResolvedValueOnce([
+      { id: 88, name: 'WC', room_type: 'facility', capacity: 5, is_occupied: false },
+    ]);
+    mockedApi.processRfidScan.mockResolvedValueOnce({
+      student_id: 42,
+      student_name: 'Lisa Schmidt',
+      action: 'checked_in',
+      room_name: 'WC',
+    });
+
+    mockRfidHookReturn = {
+      ...mockRfidHookReturn,
+      currentScan: {
+        student_id: 42,
+        student_name: 'Lisa Schmidt',
+        action: 'checked_out',
+        daily_checkout_available: false,
+        scannedTagId: '04:AA:BB:CC:DD:EE:FF',
+      },
+      showModal: true,
+    };
+
+    await act(async () => {
+      renderPage();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Toilette')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Toilette'));
+
+    await waitFor(() => {
+      expect(mockedApi.processRfidScan).toHaveBeenCalledWith(
+        { student_rfid: '04:AA:BB:CC:DD:EE:FF', action: 'checkin', room_id: 88 },
+        '1234'
+      );
+    });
+  });
+
+  it('prefers canonical WC room when both toilet aliases exist', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mockedApi.getRooms.mockResolvedValueOnce([
+      { id: 89, name: 'Toilette', room_type: 'facility', capacity: 5, is_occupied: false },
       { id: 88, name: 'WC', room_type: 'facility', capacity: 5, is_occupied: false },
     ]);
     mockedApi.processRfidScan.mockResolvedValueOnce({

--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -18,6 +18,7 @@ import {
   api,
   formatRoomName,
   mapServerErrorToGerman,
+  WC_ROOM_ALIASES,
   type RfidScanResult,
   type DailyFeedbackRating,
   type DeviceConfig,
@@ -585,13 +586,16 @@ const ActivityScanningPage: React.FC = () => {
           // Don't fail - just won't show Schulhof option
         }
 
-        // Find WC room by name
-        const wcRoom = rooms.find(r => r.name === 'WC');
+        // Find toilet room by alias, preferring the canonical backend name.
+        // WC_ROOM_ALIASES is canonical-first, so the first match wins.
+        const wcRoom = WC_ROOM_ALIASES.map(alias => rooms.find(r => r.name === alias)).find(
+          (r): r is NonNullable<typeof r> => r !== undefined
+        );
         if (wcRoom) {
           setWcRoomId(wcRoom.id);
-          logger.info('Found WC room', { id: wcRoom.id, name: wcRoom.name });
+          logger.info('Found toilet room', { id: wcRoom.id, name: wcRoom.name });
         } else {
-          logger.warn('No WC room found - Toilette button will not work');
+          logger.warn('No WC/Toilette room found - Toilette button will not work');
         }
       } catch (error) {
         logger.error('Failed to fetch Schulhof room', { error: serializeError(error) });

--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -22,6 +22,7 @@ import {
   type RfidScanResult,
   type DailyFeedbackRating,
   type DeviceConfig,
+  type Room,
 } from '../services/api';
 import { useUserStore, isNetworkRelatedError } from '../store/userStore';
 import { createLogger, serializeError } from '../utils/logger';
@@ -330,6 +331,18 @@ const isNonActionableScan = (scan: ExtendedScanResult): boolean => {
   return Boolean(scan.showAsError) || Boolean(scan.isInfo);
 };
 
+/**
+ * Returns the first room whose name matches one of the given aliases.
+ * Aliases are tried in order, so callers can pass a canonical-first list.
+ */
+const findRoomByAliases = (rooms: Room[], aliases: readonly string[]): Room | undefined => {
+  for (const alias of aliases) {
+    const match = rooms.find(r => r.name === alias);
+    if (match) return match;
+  }
+  return undefined;
+};
+
 // =============================================================================
 // End helper functions
 // =============================================================================
@@ -588,9 +601,7 @@ const ActivityScanningPage: React.FC = () => {
 
         // Find toilet room by alias, preferring the canonical backend name.
         // WC_ROOM_ALIASES is canonical-first, so the first match wins.
-        const wcRoom = WC_ROOM_ALIASES.map(alias => rooms.find(r => r.name === alias)).find(
-          (r): r is NonNullable<typeof r> => r !== undefined
-        );
+        const wcRoom = findRoomByAliases(rooms, WC_ROOM_ALIASES);
         if (wcRoom) {
           setWcRoomId(wcRoom.id);
           logger.info('Found toilet room', { id: wcRoom.id, name: wcRoom.name });

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -4,9 +4,11 @@ import {
   ApiError,
   formatRoomName,
   isNetworkRelatedError,
+  isWCRoomAlias,
   mapApiErrorToGerman,
   mapServerErrorToGerman,
   setNetworkStatusCallback,
+  WC_ROOM_ALIASES,
 } from './api';
 
 // ====================================================================
@@ -474,10 +476,59 @@ describe('formatRoomName', () => {
     expect(formatRoomName('WC')).toBe('Toilette');
   });
 
+  it('maps Toilette alias to Toilette (idempotent on the canonical UI label)', () => {
+    expect(formatRoomName('Toilette')).toBe('Toilette');
+  });
+
   it('keeps other names unchanged', () => {
     expect(formatRoomName('Turnhalle')).toBe('Turnhalle');
     expect(formatRoomName('Raum 101')).toBe('Raum 101');
     expect(formatRoomName('Schulhof')).toBe('Schulhof');
+  });
+
+  it('does not match case variants — exact-case mirror of backend IsWCRoomName', () => {
+    // Backend `IsWCRoomName` is exact-case; the kiosk must mirror that so the
+    // toilet button only lights up for rooms the backend actually treats as
+    // toilet special rooms. A lowercase "wc" lookup is intentionally NOT
+    // remapped here.
+    expect(formatRoomName('wc')).toBe('wc');
+    expect(formatRoomName('toilette')).toBe('toilette');
+  });
+});
+
+// ====================================================================
+// isWCRoomAlias / WC_ROOM_ALIASES
+// ====================================================================
+
+describe('WC_ROOM_ALIASES', () => {
+  it('lists canonical name first, alias second', () => {
+    // Order is load-bearing: ActivityScanningPage picks the first matching
+    // alias when both rooms exist on the same kiosk, so the device sends
+    // check-ins to the canonical "WC" room rather than the manually-created
+    // "Toilette" alias.
+    expect(WC_ROOM_ALIASES).toEqual(['WC', 'Toilette']);
+  });
+});
+
+describe('isWCRoomAlias', () => {
+  it('returns true for canonical WC', () => {
+    expect(isWCRoomAlias('WC')).toBe(true);
+  });
+
+  it('returns true for Toilette alias', () => {
+    expect(isWCRoomAlias('Toilette')).toBe(true);
+  });
+
+  it('returns false for case variants', () => {
+    expect(isWCRoomAlias('wc')).toBe(false);
+    expect(isWCRoomAlias('Wc')).toBe(false);
+    expect(isWCRoomAlias('toilette')).toBe(false);
+  });
+
+  it('returns false for unrelated names', () => {
+    expect(isWCRoomAlias('Schulhof')).toBe(false);
+    expect(isWCRoomAlias('Raum 101')).toBe(false);
+    expect(isWCRoomAlias('')).toBe(false);
   });
 });
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -226,11 +226,28 @@ function isStringOrNumber(value: unknown): value is string | number {
 }
 
 /**
+ * Canonical names a backend toilet special-room can come back with, in
+ * canonical-first order. The first entry is what Phoenix auto-creates;
+ * the second is an accepted alias a tenant may have created manually.
+ *
+ * Must stay in sync with Phoenix backend/constants/activities.go
+ * (WCRoomName, WCRoomAliasName) and frontend/src/lib/room-helpers.ts
+ * (SYSTEM_ROOM_NAMES). Matching is exact-case to mirror the backend's
+ * `IsWCRoomName` check. Adding a new alias requires updating all three.
+ */
+export const WC_ROOM_ALIASES = ['WC', 'Toilette'] as const;
+
+/** Returns true when the given room name is one of the toilet aliases. */
+export function isWCRoomAlias(name: string): boolean {
+  return (WC_ROOM_ALIASES as readonly string[]).includes(name);
+}
+
+/**
  * Map backend room names to German display names.
- * Backend uses "WC" internally but UI should show "Toilette".
+ * Any toilet-room alias is shown as "Toilette" in the kiosk UI.
  */
 export function formatRoomName(name: string): string {
-  if (name === 'WC') return 'Toilette';
+  if (isWCRoomAlias(name)) return 'Toilette';
   return name;
 }
 


### PR DESCRIPTION
Companion PR: https://github.com/moto-nrw/project-phoenix/pull/1355
Closes moto-nrw/project-phoenix#1184

## Summary

- New `WC_ROOM_ALIASES = ['WC', 'Toilette'] as const` and `isWCRoomAlias(name)` exported from `src/services/api.ts`. Order is canonical-first and load-bearing: when both rooms exist on the same kiosk, the canonical `WC` wins so check-ins route to the same room Phoenix's auto-create produces.
- `formatRoomName` maps either alias to the German UI label `"Toilette"` so existing user-facing copy is unchanged.
- `ActivityScanningPage` looks up the kiosk's toilet room by iterating `WC_ROOM_ALIASES` in order rather than matching `name === 'WC'`. The Toilette button now lights up for tenants who manually created a `Toilette` room without ever creating a `WC` one.
- Matching is exact-case, mirroring the backend's `IsWCRoomName` so the kiosk and Phoenix agree on which rooms count as toilet special-rooms.
- Sync note in the `WC_ROOM_ALIASES` doc-comment ties the three-way invariant: Phoenix `constants/activities.go` (`WCRoomName`, `WCRoomAliasName`), Phoenix `frontend/src/lib/room-helpers.ts` (`SYSTEM_ROOM_NAMES`), and this file. Adding a future alias requires updating all three.

## Test plan

- [ ] `pnpm test` — `formatRoomName`, `isWCRoomAlias`, `WC_ROOM_ALIASES` ordering, ActivityScanningPage Toilette-only and both-aliases canonical-preference tests all green
- [ ] `pnpm check` — eslint + tsc clean
- [ ] On a kiosk paired to a Phoenix tenant with only `WC`: Toilette button still appears and triggers check-in to room `WC`
- [ ] On a kiosk paired to a Phoenix tenant with only `Toilette`: Toilette button appears and triggers check-in to room `Toilette`
- [ ] On a kiosk paired to a tenant with both rooms (transient state during Phoenix migration 1.15.47 rollout): Toilette button routes to `WC` (canonical-first ordering)
- [ ] On a kiosk paired to a tenant with neither: Toilette button does not appear (warning logged: "No WC/Toilette room found")

## Cross-repo coordination

Depends on Phoenix PR for full effect — Phoenix needs to ship for `Toilette`-named rooms to be auto-created or recognised as system rooms server-side. Either order is safe to merge though: with old Phoenix + new PyrePortal, `Toilette`-named rooms simply aren't auto-created (the old fallback to `WC` still applies), so no kiosk behavior regresses.