### PR TITLE
Remove orphaned Phoenix error mappings

### DIFF
--- a/src/services/__snapshots__/apiErrors.test.ts.snap
+++ b/src/services/__snapshots__/apiErrors.test.ts.snap
@@ -46,24 +46,12 @@ exports[`ERROR_MESSAGE_MAPPINGS backend contract > keeps all patterns and German
     "PIN nicht angegeben.",
   ],
   [
-    "staff account is locked due to failed PIN attempts",
-    "Konto gesperrt wegen zu vieler Fehlversuche. Bitte Administrator kontaktieren.",
-  ],
-  [
-    "maximum PIN attempts exceeded",
-    "Maximale PIN-Versuche überschritten. Konto gesperrt.",
-  ],
-  [
     "locked",
     "Konto gesperrt. Bitte später erneut versuchen.",
   ],
   [
     "device is not active",
     "Gerät ist deaktiviert. Bitte Administrator kontaktieren.",
-  ],
-  [
-    "device is offline",
-    "Gerät ist als offline markiert. Bitte Administrator kontaktieren.",
   ],
   [
     "device is already running an activity session",
@@ -95,10 +83,6 @@ exports[`ERROR_MESSAGE_MAPPINGS backend contract > keeps all patterns and German
       "RFID tag not assigned",
     ],
     "Armband ist nicht zugewiesen. Bitte an Betreuer wenden.",
-  ],
-  [
-    "staff RFID authentication must be done via session management",
-    "Betreuer-Armband kann hier nicht verwendet werden.",
   ],
   [
     "student RFID tag required for pickup query",

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -84,18 +84,6 @@ describe('mapServerErrorToGerman', () => {
     );
   });
 
-  it('maps locked account', () => {
-    expect(mapServerErrorToGerman('staff account is locked due to failed PIN attempts')).toBe(
-      'Konto gesperrt wegen zu vieler Fehlversuche. Bitte Administrator kontaktieren.'
-    );
-  });
-
-  it('maps maximum PIN attempts', () => {
-    expect(mapServerErrorToGerman('maximum PIN attempts exceeded')).toBe(
-      'Maximale PIN-Versuche überschritten. Konto gesperrt.'
-    );
-  });
-
   it('maps generic locked', () => {
     expect(mapServerErrorToGerman('locked')).toBe('Konto gesperrt. Bitte später erneut versuchen.');
   });
@@ -165,12 +153,6 @@ describe('mapServerErrorToGerman', () => {
     expect(mapServerErrorToGerman('RFID tag not assigned')).toBe(
       'Armband ist nicht zugewiesen. Bitte an Betreuer wenden.'
     );
-  });
-
-  it('maps staff RFID auth error', () => {
-    expect(
-      mapServerErrorToGerman('staff RFID authentication must be done via session management')
-    ).toBe('Betreuer-Armband kann hier nicht verwendet werden.');
   });
 
   // Attendance errors
@@ -292,12 +274,6 @@ describe('mapServerErrorToGerman', () => {
 
   it('maps staff PIN is required', () => {
     expect(mapServerErrorToGerman('staff PIN is required')).toBe('PIN nicht angegeben.');
-  });
-
-  it('maps device is offline', () => {
-    expect(mapServerErrorToGerman('device is offline')).toBe(
-      'Gerät ist als offline markiert. Bitte Administrator kontaktieren.'
-    );
   });
 
   it('maps no active session', () => {

--- a/src/services/apiErrors.test.ts
+++ b/src/services/apiErrors.test.ts
@@ -18,6 +18,6 @@ describe('ERROR_MESSAGE_MAPPINGS backend contract', () => {
   });
 
   it('keeps the number of mappings stable', () => {
-    expect(ERROR_MESSAGE_MAPPINGS).toHaveLength(56);
+    expect(ERROR_MESSAGE_MAPPINGS).toHaveLength(52);
   });
 });

--- a/src/services/apiErrors.ts
+++ b/src/services/apiErrors.ts
@@ -95,16 +95,10 @@ export const ERROR_MESSAGE_MAPPINGS: readonly ErrorMapping[] = [
   ['invalid API key format', 'API-Schlüssel Format ungültig. Bearer Token erwartet.'],
   ['invalid staff PIN', 'Ungültiger PIN. Bitte erneut versuchen.'],
   ['staff PIN is required', 'PIN nicht angegeben.'],
-  [
-    'staff account is locked due to failed PIN attempts',
-    'Konto gesperrt wegen zu vieler Fehlversuche. Bitte Administrator kontaktieren.',
-  ],
-  ['maximum PIN attempts exceeded', 'Maximale PIN-Versuche überschritten. Konto gesperrt.'],
   ['locked', 'Konto gesperrt. Bitte später erneut versuchen.'], // Generic fallback for lock-related
 
   // 3. AUTHORIZATION ERRORS (403)
   ['device is not active', 'Gerät ist deaktiviert. Bitte Administrator kontaktieren.'],
-  ['device is offline', 'Gerät ist als offline markiert. Bitte Administrator kontaktieren.'],
 
   // 4. SESSION ERRORS (400/409)
   [
@@ -121,10 +115,6 @@ export const ERROR_MESSAGE_MAPPINGS: readonly ErrorMapping[] = [
   [
     ['RFID tag not found', 'RFID tag not assigned'],
     'Armband ist nicht zugewiesen. Bitte an Betreuer wenden.',
-  ],
-  [
-    'staff RFID authentication must be done via session management',
-    'Betreuer-Armband kann hier nicht verwendet werden.',
   ],
   ['student RFID tag required for pickup query', 'Bitte Schüler-Armband scannen.'],
   ['RFID parameter is required', 'RFID-Tag fehlt in der Anfrage.'],


### PR DESCRIPTION
## Summary

- remove three device-auth mappings that Phoenix has never emitted
- remove the retired supervisor-RFID rejection mapping; Phoenix restored supervisor RFID authentication in project-phoenix#694
- update focused mapping tests and the pinned 52-entry snapshot

## Why

These entries described unreachable backend responses. Keeping them made the cross-repository contract look broader than the production API and prevented Phoenix from guarding the live mapping table accurately.

Related to moto-nrw/project-phoenix#1876. The matching Phoenix guard PR will link this PR.

## Tests

- `pnpm exec vitest run src/services/apiErrors.test.ts src/services/api.test.ts`
- `pnpm run test` (55 files, 1,167 tests)
- `pnpm run check`
- `pnpm run format:check`
- pre-push: git-secrets, knip, frontend check