### PR TITLE
fix: read activity capacity details from backend keys

### DIFF
--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -329,10 +329,12 @@ describe('mapApiErrorToGerman', () => {
   });
 
   it('handles ApiError with activity capacity details', () => {
+    // Backend sends current_occupancy/max_capacity for activity capacity too
+    // (project-phoenix issue #1879)
     const error = new ApiError('Activity capacity exceeded', 409, 'ACTIVITY_CAPACITY_EXCEEDED', {
       activity_name: 'Fußball AG',
-      current_participants: 20,
-      max_participants: 20,
+      current_occupancy: 20,
+      max_capacity: 20,
     });
     const result = mapApiErrorToGerman(error);
     expect(result).toBe('Fußball AG ist voll (20/20 Teilnehmer).');
@@ -365,10 +367,21 @@ describe('mapApiErrorToGerman', () => {
     );
   });
 
+  it('activity 409 with details omitted (setting off) shows generic message', () => {
+    // The backend omits `details` when the tenant setting
+    // checkin.activity_capacity_details_enabled is off — the default
+    // (project-phoenix issue #1879). The kiosk must fall back cleanly.
+    const error = new ApiError('Activity capacity exceeded', 409, 'ACTIVITY_CAPACITY_EXCEEDED');
+    expect(error.details).toBeUndefined();
+    expect(mapApiErrorToGerman(error)).toBe(
+      'Aktivität ist voll. Maximale Teilnehmerzahl erreicht.'
+    );
+  });
+
   it('handles activity capacity with partial details', () => {
     const error = new ApiError('capacity', 409, 'ACTIVITY_CAPACITY_EXCEEDED', {
       activity_name: 'Kunst',
-      max_participants: 15,
+      max_capacity: 15,
     });
     expect(mapApiErrorToGerman(error)).toBe('Kunst ist voll (15/15 Teilnehmer).');
   });
@@ -388,7 +401,7 @@ describe('mapApiErrorToGerman', () => {
 
   it('handles activity capacity details without activity_name', () => {
     const error = new ApiError('capacity', 409, 'ACTIVITY_CAPACITY_EXCEEDED', {
-      max_participants: 15,
+      max_capacity: 15,
     });
     // No activity_name → falls back to generic message
     expect(mapApiErrorToGerman(error)).toBe(

--- a/src/services/apiErrors.ts
+++ b/src/services/apiErrors.ts
@@ -12,7 +12,8 @@ export interface ApiErrorResponse {
   message: string;
   code?: string;
   details?: {
-    // Room capacity fields
+    // Capacity fields — the backend sends current_occupancy/max_capacity for
+    // BOTH room and activity capacity errors (project-phoenix issue #1879)
     room_id?: number;
     room_name?: string;
     current_occupancy?: number;
@@ -20,8 +21,6 @@ export interface ApiErrorResponse {
     // Activity capacity fields
     activity_id?: number;
     activity_name?: string;
-    current_participants?: number;
-    max_participants?: number;
     // Duplicate-active-visit fields (Issue #844, backend STUDENT_ALREADY_ACTIVE)
     student_id?: number;
     existing_visit_id?: number;
@@ -243,12 +242,12 @@ export function formatRoomName(name: string): string {
  */
 function formatActivityCapacityError(details: Record<string, unknown>): string {
   const activityName = details.activity_name;
-  const currentParticipants = details.current_participants;
-  const maxParticipants = details.max_participants;
+  const currentOccupancy = details.current_occupancy;
+  const maxCapacity = details.max_capacity;
 
-  if (isStringOrNumber(activityName) && isStringOrNumber(maxParticipants)) {
-    const current = isStringOrNumber(currentParticipants) ? currentParticipants : maxParticipants;
-    return `${activityName} ist voll (${current}/${maxParticipants} Teilnehmer).`;
+  if (isStringOrNumber(activityName) && isStringOrNumber(maxCapacity)) {
+    const current = isStringOrNumber(currentOccupancy) ? currentOccupancy : maxCapacity;
+    return `${activityName} ist voll (${current}/${maxCapacity} Teilnehmer).`;
   }
   return 'Aktivität ist voll. Maximale Teilnehmerzahl erreicht.';
 }


### PR DESCRIPTION
## Summary

Companion PR to moto-nrw/project-phoenix#1881 (issue moto-nrw/project-phoenix#1879).

The backend sends `details.current_occupancy`/`details.max_capacity` for the activity-capacity 409 (the same keys the room error uses), but `formatActivityCapacityError` read `details.current_participants`/`details.max_participants` — keys the backend never emits. The rich German message "{Aktivität} ist voll (X/Y Teilnehmer)." therefore never rendered; kiosks always showed the generic fallback.

## Changes

- `src/services/apiErrors.ts`: `formatActivityCapacityError` now reads `current_occupancy`/`max_capacity`; the two dead participants fields are removed from the `ApiErrorResponse.details` interface. German message texts unchanged, `formatRoomCapacityError` untouched.
- `src/services/api.test.ts`: the three tests that constructed `details` with the participants keys **encoded the bug** — they are deliberately updated to the real backend keys (expected German strings unchanged). This is the user-approved contract fix from issue #1879, not a test edited to make code pass. One new test documents the backend "setting off" behavior (409 without `details` → generic message).

Not touched: the `ERROR_MESSAGE_MAPPINGS` snapshot (pins only pattern/message tuples) and the Activity entity field `max_participants` in `api.ts`/stores — a different concept from the 409 details keys. The orphaned-mapping cleanup from the issue was already done in #379.

## Behavior

The backend gates the `details` object behind the tenant setting `checkin.activity_capacity_details_enabled` (default **off**), so this fix becomes visible only for schools that opt in. Without `details` the existing generic-fallback path keeps working — old and new kiosk builds both degrade cleanly.

## Verification

- `pnpm test`: 1168 tests green
- `pnpm run check` (eslint + tsc): clean