### PR TITLE
fix: X-Staff-ID bei RFID-Scan und Attendance-Toggle mitsenden

### DIFF
--- a/src/hooks/pages/useActivityScanningPage.ts
+++ b/src/hooks/pages/useActivityScanningPage.ts
@@ -18,6 +18,7 @@ import {
   type DeviceConfig,
   type Room,
 } from '../../services/api';
+import { resolveStaffAttributionId } from '../../store/slices/authSlice';
 import { useUserStore } from '../../store/userStore';
 import { createLogger, serializeError } from '../../utils/logger';
 import { useRfidScanning } from '../useRfidScanning';
@@ -53,6 +54,7 @@ export function useActivityScanningPage() {
     authenticatedUser,
     rfid,
     currentSession,
+    selectedSupervisors,
     fetchCurrentSession,
   } = useUserStore();
 
@@ -528,7 +530,7 @@ export function useActivityScanningPage() {
         checkoutDestinationState.rfid,
         'confirm_daily_checkout',
         'zuhause',
-        authenticatedUser.staffId
+        resolveStaffAttributionId(authenticatedUser, selectedSupervisors)
       );
       logger.info('Daily checkout confirmed');
       feedbackVisitIdRef.current = currentScan?.visit_id ?? null;

--- a/src/hooks/pages/useActivityScanningPage.ts
+++ b/src/hooks/pages/useActivityScanningPage.ts
@@ -527,7 +527,8 @@ export function useActivityScanningPage() {
         authenticatedUser.pin,
         checkoutDestinationState.rfid,
         'confirm_daily_checkout',
-        'zuhause'
+        'zuhause',
+        authenticatedUser.staffId
       );
       logger.info('Daily checkout confirmed');
       feedbackVisitIdRef.current = currentScan?.visit_id ?? null;

--- a/src/hooks/pages/useCheckoutDestination.ts
+++ b/src/hooks/pages/useCheckoutDestination.ts
@@ -43,6 +43,7 @@ export function useCheckoutDestination({ schulhofRoomId, wcRoomId }: UseCheckout
       roomId: destination === 'schulhof' ? schulhofRoomId : wcRoomId,
       state: checkoutDestinationState,
       pin: authenticatedUser.pin,
+      staffId: authenticatedUser.staffId,
       recentTagScans,
     });
 

--- a/src/hooks/pages/useCheckoutDestination.ts
+++ b/src/hooks/pages/useCheckoutDestination.ts
@@ -4,6 +4,7 @@ import {
   checkInToDestinationRoom,
   type CheckoutDestinationState,
 } from '../../services/checkoutDestinationService';
+import { resolveStaffAttributionId } from '../../store/slices/authSlice';
 import { useUserStore } from '../../store/userStore';
 
 export type CheckoutDestination = 'schulhof' | 'raumwechsel' | 'toilette';
@@ -21,7 +22,7 @@ interface UseCheckoutDestinationParams {
  * the background checkout sync of the triggering scan before checking in.
  */
 export function useCheckoutDestination({ schulhofRoomId, wcRoomId }: UseCheckoutDestinationParams) {
-  const { authenticatedUser, setScanResult, showScanModal } = useUserStore();
+  const { authenticatedUser, selectedSupervisors, setScanResult, showScanModal } = useUserStore();
   const { recentTagScans } = useUserStore(state => state.rfid);
 
   // State for checkout destination selection (unified: Raumwechsel, Schulhof, nach Hause)
@@ -43,7 +44,7 @@ export function useCheckoutDestination({ schulhofRoomId, wcRoomId }: UseCheckout
       roomId: destination === 'schulhof' ? schulhofRoomId : wcRoomId,
       state: checkoutDestinationState,
       pin: authenticatedUser.pin,
-      staffId: authenticatedUser.staffId,
+      staffId: resolveStaffAttributionId(authenticatedUser, selectedSupervisors),
       recentTagScans,
     });
 

--- a/src/hooks/useRfidScanning.test.ts
+++ b/src/hooks/useRfidScanning.test.ts
@@ -682,7 +682,8 @@ describe('useRfidScanning', () => {
           action: 'checkin',
           room_id: 10,
         }),
-        '1234'
+        '1234',
+        1
       );
     });
 
@@ -1539,7 +1540,8 @@ describe('useRfidScanning', () => {
 
       expect(mockedProcessRfidScan).toHaveBeenCalledWith(
         expect.objectContaining({ student_rfid: '04:AA:BB:CC:DD:EE:FF' }),
-        '1234'
+        '1234',
+        1
       );
     });
 
@@ -1603,11 +1605,13 @@ describe('useRfidScanning', () => {
       expect(mockedProcessRfidScan).toHaveBeenCalledTimes(2);
       expect(mockedProcessRfidScan).toHaveBeenCalledWith(
         expect.objectContaining({ student_rfid: '04:AA:BB:CC:DD:EE:FF' }),
-        '1234'
+        '1234',
+        1
       );
       expect(mockedProcessRfidScan).toHaveBeenCalledWith(
         expect.objectContaining({ student_rfid: '04:11:22:33:44:55:66' }),
-        '1234'
+        '1234',
+        1
       );
     });
   });
@@ -1913,7 +1917,8 @@ describe('useRfidScanning', () => {
 
       expect(mockedProcessRfidScan).toHaveBeenCalledWith(
         { student_rfid: MOCK_TAG, action: 'checkin', room_id: 10 },
-        '1234'
+        '1234',
+        1
       );
 
       await act(async () => {

--- a/src/hooks/useRfidScanning.test.ts
+++ b/src/hooks/useRfidScanning.test.ts
@@ -660,6 +660,11 @@ describe('useRfidScanning', () => {
     });
 
     it('calls processRfidScan with correct payload', async () => {
+      setAuthenticated('1234', 0, 'OGS Device');
+      useUserStore.setState({
+        selectedSupervisors: [{ id: 7, name: 'Frau Schmidt' }],
+      });
+
       const { result } = renderHook(() => useRfidScanning());
 
       await act(async () => {
@@ -683,7 +688,33 @@ describe('useRfidScanning', () => {
           room_id: 10,
         }),
         '1234',
-        1
+        7
+      );
+    });
+
+    it('does not infer an acting staff member from multiple selected supervisors', async () => {
+      setAuthenticated('1234', 0, 'OGS Device');
+      useUserStore.setState({
+        selectedSupervisors: [
+          { id: 7, name: 'Frau Schmidt' },
+          { id: 8, name: 'Herr Müller' },
+        ],
+      });
+
+      const { result } = renderHook(() => useRfidScanning());
+
+      await act(async () => {
+        await result.current.startScanning();
+      });
+      await triggerMockScanAndDrain();
+
+      expect(mockedProcessRfidScan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'checkin',
+          room_id: 10,
+        }),
+        '1234',
+        undefined
       );
     });
 

--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -19,6 +19,7 @@ import {
   runPickupQuery,
   updateSessionActivityQuietly,
 } from '../services/scanProcessor';
+import { resolveStaffAttributionId } from '../store/slices/authSlice';
 import { useUserStore } from '../store/userStore';
 import { createLogger, serializeError } from '../utils/logger';
 
@@ -104,6 +105,7 @@ export const useRfidScanning = () => {
       const freshRoom = currentState.selectedRoom;
       const freshUser = currentState.authenticatedUser;
       const freshSession = currentState.currentSession;
+      const freshSupervisors = currentState.selectedSupervisors;
       const freshRfid = currentState.rfid;
 
       // Validate authentication state
@@ -194,7 +196,7 @@ export const useRfidScanning = () => {
         const result = await api.processRfidScan(
           { student_rfid: tagId, action: 'checkin', room_id: freshRoom.id },
           freshUser.pin,
-          freshUser.staffId
+          resolveStaffAttributionId(freshUser, freshSupervisors)
         );
 
         logger.info('RFID scan completed via server', {

--- a/src/hooks/useRfidScanning.ts
+++ b/src/hooks/useRfidScanning.ts
@@ -193,7 +193,8 @@ export const useRfidScanning = () => {
         // Make API call (server is single source of truth)
         const result = await api.processRfidScan(
           { student_rfid: tagId, action: 'checkin', room_id: freshRoom.id },
-          freshUser.pin
+          freshUser.pin,
+          freshUser.staffId
         );
 
         logger.info('RFID scan completed via server', {

--- a/src/pages/ActivityScanningPage.test.tsx
+++ b/src/pages/ActivityScanningPage.test.tsx
@@ -75,8 +75,8 @@ const defaultRfidState = {
 
 const defaultStoreState = {
   authenticatedUser: {
-    staffId: 1,
-    staffName: 'Test User',
+    staffId: 0,
+    staffName: 'OGS Device',
     deviceName: 'Test Device',
     pin: '1234',
   },

--- a/src/pages/ActivityScanningPage.test.tsx
+++ b/src/pages/ActivityScanningPage.test.tsx
@@ -758,7 +758,8 @@ describe('ActivityScanningPage', () => {
     await waitFor(() => {
       expect(mockedApi.processRfidScan).toHaveBeenCalledWith(
         { student_rfid: '04:AA:BB:CC:DD:EE:FF', action: 'checkin', room_id: 99 },
-        '1234'
+        '1234',
+        1
       );
     });
   });
@@ -873,7 +874,8 @@ describe('ActivityScanningPage', () => {
     await waitFor(() => {
       expect(mockedApi.processRfidScan).toHaveBeenCalledWith(
         { student_rfid: '04:AA:BB:CC:DD:EE:FF', action: 'checkin', room_id: 88 },
-        '1234'
+        '1234',
+        1
       );
     });
   });
@@ -916,7 +918,8 @@ describe('ActivityScanningPage', () => {
     await waitFor(() => {
       expect(mockedApi.processRfidScan).toHaveBeenCalledWith(
         { student_rfid: '04:AA:BB:CC:DD:EE:FF', action: 'checkin', room_id: 88 },
-        '1234'
+        '1234',
+        1
       );
     });
   });
@@ -1021,7 +1024,8 @@ describe('ActivityScanningPage', () => {
         '1234',
         '04:AA:BB:CC:DD:EE:FF',
         'confirm_daily_checkout',
-        'zuhause'
+        'zuhause',
+        1
       );
     });
 

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -1783,6 +1783,27 @@ describe('api methods', () => {
         })
       );
     });
+
+    it('sends X-Staff-ID when a staff member was resolved', async () => {
+      const { api: freshApi } = await getFreshApi();
+
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          status: 'success',
+          data: { student_id: 1, student_name: 'Test', action: 'checked_in' },
+          message: 'ok',
+        })
+      );
+
+      await freshApi.processRfidScan(
+        { student_rfid: 'AA:BB:CC', action: 'checkin', room_id: 5 },
+        '1234',
+        7
+      );
+
+      const options = mockFetch.mock.calls[0]?.[1] as RequestInit;
+      expect((options.headers as Record<string, string>)['X-Staff-ID']).toBe('7');
+    });
   });
 
   // ------------------------------------------------------------------
@@ -1889,6 +1910,23 @@ describe('api methods', () => {
       };
       expect(body.destination).toBe('zuhause');
       expect(body.action).toBe('confirm_daily_checkout');
+    });
+
+    it('sends X-Staff-ID when a staff member was resolved', async () => {
+      const { api: freshApi } = await getFreshApi();
+
+      mockFetch.mockResolvedValueOnce(
+        mockResponse({
+          status: 'success',
+          data: { action: 'checked_out' },
+          message: 'ok',
+        })
+      );
+
+      await freshApi.toggleAttendance('1234', 'AA:BB:CC', 'confirm', undefined, 7);
+
+      const options = mockFetch.mock.calls[0]?.[1] as RequestInit;
+      expect((options.headers as Record<string, string>)['X-Staff-ID']).toBe('7');
     });
 
     it('maps 404 error to toggle-specific German message', async () => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -640,7 +640,8 @@ export const api = {
       action: 'checkin' | 'checkout';
       room_id: number;
     },
-    pin: string
+    pin: string,
+    staffId?: number
   ): Promise<RfidScanResult> {
     const response = await apiCall<{
       data: RfidScanResult;
@@ -648,7 +649,9 @@ export const api = {
       status: string;
     }>('/api/iot/checkin', {
       method: 'POST',
-      headers: buildAuthHeaders(pin),
+      // staffId (X-Staff-ID) attributes the scan to the logged-in staff member
+      // so the backend can mark them present (project-phoenix #1439).
+      headers: buildAuthHeaders(pin, staffId && staffId > 0 ? staffId : undefined),
       body: JSON.stringify(scanData),
     });
 
@@ -711,7 +714,8 @@ export const api = {
     pin: string,
     rfid: string,
     action: 'confirm' | 'cancel' | 'confirm_daily_checkout',
-    destination?: 'zuhause' | 'unterwegs'
+    destination?: 'zuhause' | 'unterwegs',
+    staffId?: number
   ): Promise<AttendanceToggleResponse> {
     try {
       const body: { rfid: string; action: string; destination?: string } = {
@@ -726,7 +730,9 @@ export const api = {
 
       const response = await apiCall<AttendanceToggleResponse>('/api/iot/attendance/toggle', {
         method: 'POST',
-        headers: buildAuthHeaders(pin),
+        // staffId (X-Staff-ID) attributes the toggle to the logged-in staff
+        // member so the backend can mark them present (project-phoenix #1439).
+        headers: buildAuthHeaders(pin, staffId && staffId > 0 ? staffId : undefined),
         body: JSON.stringify(body),
       });
 

--- a/src/services/checkoutDestinationService.test.ts
+++ b/src/services/checkoutDestinationService.test.ts
@@ -91,6 +91,7 @@ describe('checkInToDestinationRoom', () => {
         roomId: 9,
         state: makeState(),
         pin: '1234',
+        staffId: 7,
         recentTagScans: new Map(),
       });
 
@@ -100,7 +101,8 @@ describe('checkInToDestinationRoom', () => {
           action: 'checkin',
           room_id: 9,
         },
-        '1234'
+        '1234',
+        7
       );
       expect(result).toEqual({
         ...serverResult,
@@ -115,6 +117,7 @@ describe('checkInToDestinationRoom', () => {
         roomId: 11,
         state: makeState(),
         pin: '1234',
+        staffId: 7,
         recentTagScans: new Map(),
       });
 
@@ -124,7 +127,8 @@ describe('checkInToDestinationRoom', () => {
           action: 'checkin',
           room_id: 11,
         },
-        '1234'
+        '1234',
+        7
       );
       expect(result).toEqual({
         ...serverResult,

--- a/src/services/checkoutDestinationService.ts
+++ b/src/services/checkoutDestinationService.ts
@@ -66,6 +66,7 @@ export interface CheckInToDestinationParams {
   roomId: number | null;
   state: CheckoutDestinationState;
   pin: string;
+  staffId?: number;
   recentTagScans: Map<string, RecentTagScan>;
 }
 
@@ -82,7 +83,7 @@ export interface CheckInToDestinationParams {
 export const checkInToDestinationRoom = async (
   params: CheckInToDestinationParams
 ): Promise<RfidScanResult> => {
-  const { destination, roomId, state, pin, recentTagScans } = params;
+  const { destination, roomId, state, pin, staffId, recentTagScans } = params;
   const config = DESTINATION_ROOM_CONFIGS[destination];
 
   if (!roomId) {
@@ -120,7 +121,8 @@ export const checkInToDestinationRoom = async (
         action: 'checkin',
         room_id: roomId,
       },
-      pin
+      pin,
+      staffId
     );
 
     logger.info(`${config.logLabel} check-in successful`, {

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -27,6 +27,28 @@ export interface AuthenticatedUser {
   pin: string; // Store PIN for subsequent API calls
 }
 
+/**
+ * Resolve the staff member who can safely receive attribution for a kiosk action.
+ *
+ * Global-PIN logins have no staff identity (`staffId: 0`). In that flow, a sole
+ * selected supervisor is unambiguous. Multiple supervisors require an explicit
+ * acting-person choice, so no ID is inferred.
+ */
+export function resolveStaffAttributionId(
+  authenticatedUser: AuthenticatedUser,
+  selectedSupervisors: readonly User[]
+): number | undefined {
+  if (authenticatedUser.staffId > 0) {
+    return authenticatedUser.staffId;
+  }
+
+  if (selectedSupervisors.length === 1 && selectedSupervisors[0].id > 0) {
+    return selectedSupervisors[0].id;
+  }
+
+  return undefined;
+}
+
 export const createAuthSlice = (set: SetState<UserState>, get: GetState<UserState>) => ({
   // Initial state
   users: [] as User[],


### PR DESCRIPTION
Teil von moto-nrw/project-phoenix#1439 (Backend-PR: moto-nrw/project-phoenix#1994).

`processRfidScan` und `toggleAttendance` senden jetzt die `staffId` der angemeldeten Betreuungsperson als `X-Staff-ID`-Header mit (über das bestehende `buildAuthHeaders`, das den Header bereits für die Staff-Clock nutzt). Das Backend löst den Header in Staff-Kontext auf und kann damit im Binary-Mode

- den Checkin/Checkout dem Mitarbeiter zuschreiben (`checked_in_by`/`checked_out_by`),
- die Person als anwesend stempeln (Work-Session, Quelle `nfc`).

Der Header ist optional und rein attributiv; ältere Backends ignorieren ihn.

Tests: bestehende Assertions um das neue Argument erweitert (rein mechanisch), `pnpm test` 1234/1234 grün, `pnpm run check` sauber.