### PR TITLE
Raumfarbe auf dem Check-in-Bildschirm anzeigen

### DIFF
--- a/src/pages/ActivityScanningPage.test.tsx
+++ b/src/pages/ActivityScanningPage.test.tsx
@@ -189,24 +189,22 @@ describe('ActivityScanningPage', () => {
     });
   });
 
-  it('uses the neutral frame when the selected room has no color', () => {
+  it('does not show a room-color frame when the selected room has no color', () => {
     renderPage();
 
-    expect(screen.getByTestId('room-color-frame')).toHaveStyle({
-      backgroundColor: '#D1D5DB',
-    });
+    expect(screen.getByTestId('room-color-frame').style.backgroundColor).toBe('');
+    expect(screen.getByTestId('room-color-inset')).toHaveStyle({ padding: '0px' });
   });
 
-  it('uses the neutral frame when the selected room color is invalid', () => {
+  it('does not show a room-color frame when the selected room color is invalid', () => {
     useUserStore.setState({
       selectedRoom: { ...defaultStoreState.selectedRoom, color: 'not-a-color' },
     });
 
     renderPage();
 
-    expect(screen.getByTestId('room-color-frame')).toHaveStyle({
-      backgroundColor: '#D1D5DB',
-    });
+    expect(screen.getByTestId('room-color-frame').style.backgroundColor).toBe('');
+    expect(screen.getByTestId('room-color-inset')).toHaveStyle({ padding: '0px' });
   });
 
   it('shows a different activity name when store is updated', () => {

--- a/src/pages/ActivityScanningPage.test.tsx
+++ b/src/pages/ActivityScanningPage.test.tsx
@@ -193,7 +193,18 @@ describe('ActivityScanningPage', () => {
     renderPage();
 
     expect(screen.getByTestId('room-color-frame').style.backgroundColor).toBe('');
+    expect(screen.getByTestId('room-color-frame')).toHaveStyle({ padding: '0px' });
     expect(screen.getByTestId('room-color-inset')).toHaveStyle({ padding: '0px' });
+  });
+
+  it('keeps the unframed waiting screen flush to the viewport', () => {
+    renderPage();
+
+    expect(screen.getByTestId('room-color-frame')).toHaveStyle({ padding: '0px' });
+    expect(screen.getByLabelText('Abholzeit abfragen')).toHaveStyle({
+      top: '20px',
+      left: '20px',
+    });
   });
 
   it('does not show a room-color frame when the selected room color is invalid', () => {

--- a/src/pages/ActivityScanningPage.test.tsx
+++ b/src/pages/ActivityScanningPage.test.tsx
@@ -162,6 +162,53 @@ describe('ActivityScanningPage', () => {
     expect(screen.getByText('Raum 101')).toBeInTheDocument();
   });
 
+  it('uses a light selected room color for the waiting-screen frame', () => {
+    useUserStore.setState({
+      selectedRoom: { ...defaultStoreState.selectedRoom, color: '#F4D35E' },
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId('room-color-frame')).toHaveStyle({
+      backgroundColor: '#F4D35E',
+    });
+  });
+
+  it('uses a dark selected room color without recoloring the waiting-screen content', () => {
+    useUserStore.setState({
+      selectedRoom: { ...defaultStoreState.selectedRoom, color: '#2457A6' },
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId('room-color-frame')).toHaveStyle({
+      backgroundColor: '#2457A6',
+    });
+    expect(screen.getByTestId('room-color-content')).toHaveStyle({
+      backgroundColor: '#FFFFFF',
+    });
+  });
+
+  it('uses the neutral frame when the selected room has no color', () => {
+    renderPage();
+
+    expect(screen.getByTestId('room-color-frame')).toHaveStyle({
+      backgroundColor: '#D1D5DB',
+    });
+  });
+
+  it('uses the neutral frame when the selected room color is invalid', () => {
+    useUserStore.setState({
+      selectedRoom: { ...defaultStoreState.selectedRoom, color: 'not-a-color' },
+    });
+
+    renderPage();
+
+    expect(screen.getByTestId('room-color-frame')).toHaveStyle({
+      backgroundColor: '#D1D5DB',
+    });
+  });
+
   it('shows a different activity name when store is updated', () => {
     useUserStore.setState({
       selectedActivity: { ...defaultStoreState.selectedActivity, name: 'Hausaufgabenbetreuung' },

--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -137,6 +137,12 @@ const DESTINATION_COLORS = {
   },
 };
 
+const ROOM_COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/;
+
+function getRoomFrameColor(color: string | undefined): string {
+  return color && ROOM_COLOR_PATTERN.test(color) ? color : designSystem.gray[300];
+}
+
 // Static SVG icons hoisted out of render path to avoid per-render allocation on Pi.
 // stroke/fill use currentColor so each destination button tints its own icon.
 const ICON_RAUMWECHSEL = (
@@ -276,6 +282,8 @@ const ActivityScanningPage: React.FC = () => {
     handleModalTimeout,
     handleAnmelden,
   } = useActivityScanningPage();
+
+  const roomFrameColor = getRoomFrameColor(selectedRoom?.color);
 
   // Guard clause - if data is missing, show loading or error state
   if (!selectedActivity || !selectedRoom || !authenticatedUser) {
@@ -672,169 +680,192 @@ const ActivityScanningPage: React.FC = () => {
     <>
       <BackgroundWrapper>
         <div
+          data-testid="room-color-frame"
           style={{
             width: '100vw',
             height: '100vh',
-            padding: '16px',
-            display: 'flex',
-            flexDirection: 'column',
-            position: 'relative',
+            padding: '22px',
+            backgroundColor: roomFrameColor,
           }}
         >
-          {/* Anmelden Button - Top Right */}
-          <div
-            style={{
-              position: 'absolute',
-              top: '20px',
-              right: '20px',
-              zIndex: 10,
-            }}
-          >
-            <BackButton
-              onClick={handleAnmelden}
-              text={texts.loginButton}
-              customIcon={
-                <svg
-                  width="28"
-                  height="28"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="#374151"
-                  strokeWidth="2.5"
-                >
-                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-                  <circle cx="12" cy="7" r="4" />
-                </svg>
-              }
-              ariaLabel={texts.loginAriaLabel}
-            />
-          </div>
-
-          <button
-            type="button"
-            onClick={handlePickupQueryClick}
-            disabled={pickupQueryButtonDisabled}
-            aria-label={texts.pickupQueryAriaLabel}
-            style={{
-              position: 'absolute',
-              top: '20px',
-              left: '20px',
-              zIndex: 10,
-              width: '76px',
-              height: '76px',
-              borderRadius: '50%',
-              border: 'none',
-              backgroundColor: pickupQueryButtonDisabled
-                ? designSystem.gray[400]
-                : designSystem.gray[900],
-              color: designSystem.colors.white,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              boxShadow: pickupQueryButtonDisabled ? 'none' : designSystem.shadows.md,
-              cursor: pickupQueryButtonDisabled ? 'not-allowed' : 'pointer',
-              transition:
-                'transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease',
-              opacity: pickupQueryButtonDisabled ? 0.7 : 1,
-            }}
-            onPointerDown={e => {
-              if (pickupQueryButtonDisabled) return;
-              e.currentTarget.style.transform = 'scale(0.96)';
-            }}
-            onPointerUp={e => {
-              e.currentTarget.style.transform = 'scale(1)';
-            }}
-            onPointerLeave={e => {
-              e.currentTarget.style.transform = 'scale(1)';
-            }}
-          >
-            <FontAwesomeIcon icon={faClock} style={{ fontSize: '34px' }} />
-          </button>
-
           <div
             style={{
               width: '100%',
               height: '100%',
-              display: 'flex',
-              flexDirection: 'column',
-              position: 'relative',
-              padding: '24px',
+              padding: '18px',
+              borderRadius: '34px',
+              backgroundColor: 'rgba(255, 255, 255, 0.38)',
             }}
           >
-            {/* Header Section */}
             <div
+              data-testid="room-color-content"
               style={{
-                textAlign: 'center',
-                marginTop: '40px',
-                marginBottom: '20px',
-              }}
-            >
-              <h1
-                style={{
-                  fontSize: '56px',
-                  fontWeight: 700,
-                  color: designSystem.gray[900],
-                  margin: 0,
-                  lineHeight: 1.2,
-                }}
-              >
-                {selectedActivity.name}
-              </h1>
-              <p
-                style={{
-                  fontSize: '32px',
-                  color: designSystem.gray[500],
-                  margin: 0,
-                  fontWeight: 500,
-                }}
-              >
-                {selectedRoom?.name || texts.unknownRoom}
-              </p>
-            </div>
-
-            {/* Main Student Count Display / RFID Processing Spinner (cross-fade) */}
-            <div
-              style={{
+                width: '100%',
+                height: '100%',
                 display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                textAlign: 'center',
-                flex: 1,
+                flexDirection: 'column',
                 position: 'relative',
+                overflow: 'hidden',
+                borderRadius: '20px',
+                backgroundColor: designSystem.colors.white,
               }}
             >
-              <div
-                style={{
-                  fontSize: '220px',
-                  fontWeight: 800,
-                  // Darker pastel-family green (design review: modal green tone,
-                  // not the bright brand green)
-                  color: designSystem.pastel.green.accent,
-                  lineHeight: 1,
-                  fontVariantNumeric: 'tabular-nums',
-                  marginTop: '-12px',
-                  opacity: processingQueueSize > 0 ? 0 : 1,
-                }}
-              >
-                {studentCount ?? 0}
-              </div>
+              {/* Anmelden Button - Top Right */}
               <div
                 style={{
                   position: 'absolute',
-                  width: '140px',
-                  height: '140px',
-                  borderRadius: '50%',
-                  background: `conic-gradient(from 0deg, ${designSystem.gray[200]} 0%, ${designSystem.gray[900]} 100%)`,
-                  mask: 'radial-gradient(farthest-side, transparent calc(100% - 8px), #000 calc(100% - 8px))',
-                  WebkitMask:
-                    'radial-gradient(farthest-side, transparent calc(100% - 8px), #000 calc(100% - 8px))',
-                  animation:
-                    processingQueueSize > 0 ? 'rfid-center-spin 0.8s linear infinite' : 'none',
-                  transition: 'opacity 0.3s ease',
-                  opacity: processingQueueSize > 0 ? 1 : 0,
-                  pointerEvents: 'none',
+                  top: '20px',
+                  right: '20px',
+                  zIndex: 10,
                 }}
-              />
+              >
+                <BackButton
+                  onClick={handleAnmelden}
+                  text={texts.loginButton}
+                  customIcon={
+                    <svg
+                      width="28"
+                      height="28"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="#374151"
+                      strokeWidth="2.5"
+                    >
+                      <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                      <circle cx="12" cy="7" r="4" />
+                    </svg>
+                  }
+                  ariaLabel={texts.loginAriaLabel}
+                />
+              </div>
+
+              <button
+                type="button"
+                onClick={handlePickupQueryClick}
+                disabled={pickupQueryButtonDisabled}
+                aria-label={texts.pickupQueryAriaLabel}
+                style={{
+                  position: 'absolute',
+                  top: '20px',
+                  left: '20px',
+                  zIndex: 10,
+                  width: '76px',
+                  height: '76px',
+                  borderRadius: '50%',
+                  border: 'none',
+                  backgroundColor: pickupQueryButtonDisabled
+                    ? designSystem.gray[400]
+                    : designSystem.gray[900],
+                  color: designSystem.colors.white,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  boxShadow: pickupQueryButtonDisabled ? 'none' : designSystem.shadows.md,
+                  cursor: pickupQueryButtonDisabled ? 'not-allowed' : 'pointer',
+                  transition:
+                    'transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease',
+                  opacity: pickupQueryButtonDisabled ? 0.7 : 1,
+                }}
+                onPointerDown={e => {
+                  if (pickupQueryButtonDisabled) return;
+                  e.currentTarget.style.transform = 'scale(0.96)';
+                }}
+                onPointerUp={e => {
+                  e.currentTarget.style.transform = 'scale(1)';
+                }}
+                onPointerLeave={e => {
+                  e.currentTarget.style.transform = 'scale(1)';
+                }}
+              >
+                <FontAwesomeIcon icon={faClock} style={{ fontSize: '34px' }} />
+              </button>
+
+              <div
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  position: 'relative',
+                  padding: '24px',
+                }}
+              >
+                {/* Header Section */}
+                <div
+                  style={{
+                    textAlign: 'center',
+                    marginTop: '40px',
+                    marginBottom: '20px',
+                  }}
+                >
+                  <h1
+                    style={{
+                      fontSize: '56px',
+                      fontWeight: 700,
+                      color: designSystem.gray[900],
+                      margin: 0,
+                      lineHeight: 1.2,
+                    }}
+                  >
+                    {selectedActivity.name}
+                  </h1>
+                  <p
+                    style={{
+                      fontSize: '32px',
+                      color: designSystem.gray[500],
+                      margin: 0,
+                      fontWeight: 500,
+                    }}
+                  >
+                    {selectedRoom?.name || texts.unknownRoom}
+                  </p>
+                </div>
+
+                {/* Main Student Count Display / RFID Processing Spinner (cross-fade) */}
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    textAlign: 'center',
+                    flex: 1,
+                    position: 'relative',
+                  }}
+                >
+                  <div
+                    style={{
+                      fontSize: '220px',
+                      fontWeight: 800,
+                      // Darker pastel-family green (design review: modal green tone,
+                      // not the bright brand green)
+                      color: designSystem.pastel.green.accent,
+                      lineHeight: 1,
+                      fontVariantNumeric: 'tabular-nums',
+                      marginTop: '-12px',
+                      opacity: processingQueueSize > 0 ? 0 : 1,
+                    }}
+                  >
+                    {studentCount ?? 0}
+                  </div>
+                  <div
+                    style={{
+                      position: 'absolute',
+                      width: '140px',
+                      height: '140px',
+                      borderRadius: '50%',
+                      background: `conic-gradient(from 0deg, ${designSystem.gray[200]} 0%, ${designSystem.gray[900]} 100%)`,
+                      mask: 'radial-gradient(farthest-side, transparent calc(100% - 8px), #000 calc(100% - 8px))',
+                      WebkitMask:
+                        'radial-gradient(farthest-side, transparent calc(100% - 8px), #000 calc(100% - 8px))',
+                      animation:
+                        processingQueueSize > 0 ? 'rfid-center-spin 0.8s linear infinite' : 'none',
+                      transition: 'opacity 0.3s ease',
+                      opacity: processingQueueSize > 0 ? 1 : 0,
+                      pointerEvents: 'none',
+                    }}
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -684,7 +684,7 @@ const ActivityScanningPage: React.FC = () => {
           style={{
             width: '100vw',
             height: '100vh',
-            padding: roomFrameColor ? '22px' : '16px',
+            padding: roomFrameColor ? '22px' : 0,
             backgroundColor: roomFrameColor,
           }}
         >

--- a/src/pages/ActivityScanningPage.tsx
+++ b/src/pages/ActivityScanningPage.tsx
@@ -139,8 +139,8 @@ const DESTINATION_COLORS = {
 
 const ROOM_COLOR_PATTERN = /^#[0-9A-Fa-f]{6}$/;
 
-function getRoomFrameColor(color: string | undefined): string {
-  return color && ROOM_COLOR_PATTERN.test(color) ? color : designSystem.gray[300];
+function getRoomFrameColor(color: string | undefined): string | undefined {
+  return color && ROOM_COLOR_PATTERN.test(color) ? color : undefined;
 }
 
 // Static SVG icons hoisted out of render path to avoid per-render allocation on Pi.
@@ -684,17 +684,18 @@ const ActivityScanningPage: React.FC = () => {
           style={{
             width: '100vw',
             height: '100vh',
-            padding: '22px',
+            padding: roomFrameColor ? '22px' : '16px',
             backgroundColor: roomFrameColor,
           }}
         >
           <div
+            data-testid="room-color-inset"
             style={{
               width: '100%',
               height: '100%',
-              padding: '18px',
-              borderRadius: '34px',
-              backgroundColor: 'rgba(255, 255, 255, 0.38)',
+              padding: roomFrameColor ? '18px' : 0,
+              borderRadius: roomFrameColor ? '34px' : 0,
+              backgroundColor: roomFrameColor ? 'rgba(255, 255, 255, 0.38)' : undefined,
             }}
           >
             <div
@@ -706,8 +707,8 @@ const ActivityScanningPage: React.FC = () => {
                 flexDirection: 'column',
                 position: 'relative',
                 overflow: 'hidden',
-                borderRadius: '20px',
-                backgroundColor: designSystem.colors.white,
+                borderRadius: roomFrameColor ? '20px' : 0,
+                backgroundColor: roomFrameColor ? designSystem.colors.white : undefined,
               }}
             >
               {/* Anmelden Button - Top Right */}

--- a/src/store/slices/sessionSlice.ts
+++ b/src/store/slices/sessionSlice.ts
@@ -147,9 +147,10 @@ const resolveSessionActivity = async (
 };
 
 /**
- * Creates room object from session data if available.
+ * Creates a fallback room object when full data is unavailable.
+ * Used during session restoration when the rooms API call fails or returns no match.
  */
-const createSessionRoom = (session: CurrentSession): Room | null => {
+const createFallbackRoom = (session: CurrentSession): Room | null => {
   if (!session.room_id || !session.room_name) {
     return null;
   }
@@ -159,6 +160,90 @@ const createSessionRoom = (session: CurrentSession): Room | null => {
     name: session.room_name,
     is_occupied: true, // Current session room is always occupied
   };
+};
+
+/**
+ * Fetches room data from API during session restoration.
+ * Returns the matching room or a fallback if not found.
+ */
+const fetchRoomForSession = async (session: CurrentSession, pin: string): Promise<Room | null> => {
+  const fallback = createFallbackRoom(session);
+  if (!fallback) {
+    return null;
+  }
+
+  try {
+    storeLogger.debug('Fetching rooms to restore complete session room data', {
+      roomId: session.room_id,
+    });
+
+    const rooms = await api.getRooms(pin);
+    const matchingRoom = rooms.find(room => room.id === session.room_id);
+
+    if (matchingRoom) {
+      storeLogger.info('Session room restored from API with complete data', {
+        roomId: matchingRoom.id,
+        roomName: matchingRoom.name,
+        hasColor: Boolean(matchingRoom.color),
+      });
+      return {
+        ...matchingRoom,
+        name: session.room_name ?? matchingRoom.name,
+        is_occupied: true,
+      };
+    }
+
+    storeLogger.warn(
+      'Room not found in API response during session restoration, using fallback with limited data',
+      {
+        roomId: session.room_id,
+        availableRoomIds: rooms.map(room => room.id),
+      }
+    );
+    return fallback;
+  } catch (error) {
+    storeLogger.error('Failed to fetch rooms during session restoration, using fallback', {
+      error: error instanceof Error ? error.message : 'Unknown error',
+      roomId: session.room_id,
+    });
+    return fallback;
+  }
+};
+
+/**
+ * Resolves room data for session restoration.
+ * Uses the current selection or cached rooms when available, otherwise fetches from API.
+ */
+const resolveSessionRoom = async (
+  session: CurrentSession,
+  currentSelectedRoom: Room | null,
+  currentRooms: Room[],
+  pin: string
+): Promise<Room | null> => {
+  if (!session.room_id || !session.room_name) {
+    return null;
+  }
+
+  const cachedRoom = currentRooms.find(room => room.id === session.room_id);
+
+  if (currentSelectedRoom?.id === session.room_id) {
+    return {
+      ...currentSelectedRoom,
+      ...(cachedRoom?.color ? { color: cachedRoom.color } : {}),
+      name: session.room_name,
+      is_occupied: true,
+    };
+  }
+
+  if (cachedRoom) {
+    return {
+      ...cachedRoom,
+      name: session.room_name,
+      is_occupied: true,
+    };
+  }
+
+  return fetchRoomForSession(session, pin);
 };
 
 /**
@@ -327,7 +412,12 @@ export const createSessionSlice = (set: SetState<UserState>, get: GetState<UserS
           authenticatedUser.pin,
           authenticatedUser.staffName
         );
-        const sessionRoom = createSessionRoom(session);
+        const sessionRoom = await resolveSessionRoom(
+          session,
+          get().selectedRoom,
+          get().rooms,
+          authenticatedUser.pin
+        );
 
         // Guard: Don't overwrite selectedRoom if user just manually selected a room
         // This prevents stale server data from reverting a recent room switch.

--- a/src/store/slices/sessionSlice.ts
+++ b/src/store/slices/sessionSlice.ts
@@ -212,7 +212,8 @@ const fetchRoomForSession = async (session: CurrentSession, pin: string): Promis
 
 /**
  * Resolves room data for session restoration.
- * Uses the current selection or cached rooms when available, otherwise fetches from API.
+ * Prefers a selected or cached room that already has a color; otherwise fetches
+ * so a previous colorless fallback does not stick for the rest of the session.
  */
 const resolveSessionRoom = async (
   session: CurrentSession,
@@ -226,7 +227,7 @@ const resolveSessionRoom = async (
 
   const cachedRoom = currentRooms.find(room => room.id === session.room_id);
 
-  if (currentSelectedRoom?.id === session.room_id) {
+  if (currentSelectedRoom?.id === session.room_id && currentSelectedRoom.color) {
     return {
       ...currentSelectedRoom,
       ...(cachedRoom?.color ? { color: cachedRoom.color } : {}),
@@ -235,7 +236,7 @@ const resolveSessionRoom = async (
     };
   }
 
-  if (cachedRoom) {
+  if (cachedRoom?.color) {
     return {
       ...cachedRoom,
       name: session.room_name,

--- a/src/store/slices/sessionSlice.ts
+++ b/src/store/slices/sessionSlice.ts
@@ -300,6 +300,9 @@ const SESSION_INITIAL_STATE = {
 export const createSessionSlice = (set: SetState<UserState>, get: GetState<UserState>) => {
   // Race guard for session recreation: stale async responses are discarded
   const recreationTracker = createSessionRequestTracker();
+  // Separate guard for fetchCurrentSession so a late room/activity lookup
+  // cannot repopulate session state after logout or a newer fetch.
+  const currentSessionFetchTracker = createSessionRequestTracker();
 
   return {
     // Initial state
@@ -315,9 +318,10 @@ export const createSessionSlice = (set: SetState<UserState>, get: GetState<UserS
 
     setCurrentSession: (session: CurrentSession) => set({ currentSession: session }),
 
-    // Invalidate all in-flight recreation requests (e.g. on logout)
+    // Invalidate all in-flight recreation and current-session fetches (e.g. on logout)
     invalidateSessionRecreation: () => {
       recreationTracker.invalidate();
+      currentSessionFetchTracker.invalidate();
       set({ isValidatingLastSession: false });
     },
 
@@ -378,6 +382,7 @@ export const createSessionSlice = (set: SetState<UserState>, get: GetState<UserS
     },
 
     fetchCurrentSession: async () => {
+      const requestId = currentSessionFetchTracker.begin();
       const { authenticatedUser } = get();
 
       if (!authenticatedUser?.pin) {
@@ -385,9 +390,26 @@ export const createSessionSlice = (set: SetState<UserState>, get: GetState<UserS
         return;
       }
 
+      const isFetchStillCurrent = (): boolean => {
+        if (!currentSessionFetchTracker.isCurrent(requestId)) {
+          return false;
+        }
+
+        const currentUser = get().authenticatedUser;
+        return (
+          currentUser?.pin === authenticatedUser.pin &&
+          currentUser.staffId === authenticatedUser.staffId
+        );
+      };
+
       try {
         storeLogger.info('Fetching current session for device');
         const session = await api.getCurrentSession(authenticatedUser.pin);
+
+        if (!isFetchStillCurrent()) {
+          storeLogger.warn('Discarding stale fetchCurrentSession result');
+          return;
+        }
 
         if (!session) {
           storeLogger.debug('No active session found for device, clearing session state');
@@ -418,6 +440,11 @@ export const createSessionSlice = (set: SetState<UserState>, get: GetState<UserS
           get().rooms,
           authenticatedUser.pin
         );
+
+        if (!isFetchStillCurrent()) {
+          storeLogger.warn('Discarding stale fetchCurrentSession result after room lookup');
+          return;
+        }
 
         // Guard: Don't overwrite selectedRoom if user just manually selected a room
         // This prevents stale server data from reverting a recent room switch.

--- a/src/store/userStore.test.ts
+++ b/src/store/userStore.test.ts
@@ -621,6 +621,82 @@ describe('fetchCurrentSession', () => {
       is_occupied: true,
     });
   });
+
+  it('discards a late room lookup after logout', async () => {
+    setAuthenticated();
+    const session: CurrentSession = {
+      active_group_id: 1,
+      activity_id: 10,
+      activity_name: 'Fußball AG',
+      device_id: 1,
+      start_time: '2024-01-01T10:00:00Z',
+      duration: '2h',
+      room_id: 5,
+      room_name: 'Turnhalle',
+      is_active: true,
+    };
+    mockGetCurrentSession.mockResolvedValueOnce(session);
+    mockGetActivities.mockResolvedValueOnce([mockActivity({ id: 10, name: 'Fußball AG' })]);
+
+    let resolveRooms: (rooms: Room[]) => void = () => undefined;
+    mockGetRooms.mockImplementationOnce(
+      () =>
+        new Promise<Room[]>(resolve => {
+          resolveRooms = resolve;
+        })
+    );
+
+    const fetchPromise = useUserStore.getState().fetchCurrentSession();
+    await vi.waitFor(() => {
+      expect(mockGetRooms).toHaveBeenCalled();
+    });
+
+    await useUserStore.getState().logout();
+    resolveRooms([mockRoom({ id: 5, name: 'Turnhalle', color: '#F4D35E' })]);
+    await fetchPromise;
+
+    const state = useUserStore.getState();
+    expect(state.authenticatedUser).toBeNull();
+    expect(state.currentSession).toBeNull();
+    expect(state.selectedRoom).toBeNull();
+    expect(state.selectedActivity).toBeNull();
+    expect(state.selectedSupervisors).toHaveLength(0);
+  });
+
+  it('does not clear a newer login when a stale fetch finds no session', async () => {
+    setAuthenticated();
+    mockGetCurrentSession.mockImplementationOnce(
+      () =>
+        new Promise<CurrentSession | null>(resolve => {
+          queueMicrotask(() => resolve(null));
+        })
+    );
+
+    const fetchPromise = useUserStore.getState().fetchCurrentSession();
+    await useUserStore.getState().logout();
+    useUserStore.getState().setAuthenticatedUser({
+      staffId: 2,
+      staffName: 'Herr Müller',
+      deviceName: 'Pi-5',
+      pin: '5678',
+    });
+    useUserStore.setState({
+      currentSession: {
+        active_group_id: 9,
+        activity_id: 3,
+        device_id: 1,
+        start_time: 'now',
+        duration: '1h',
+      },
+      selectedRoom: mockRoom({ id: 3, name: 'Raum B' }),
+    });
+    await fetchPromise;
+
+    const state = useUserStore.getState();
+    expect(state.authenticatedUser?.staffId).toBe(2);
+    expect(state.currentSession?.active_group_id).toBe(9);
+    expect(state.selectedRoom?.id).toBe(3);
+  });
 });
 
 // ====================================================================

--- a/src/store/userStore.test.ts
+++ b/src/store/userStore.test.ts
@@ -514,6 +514,113 @@ describe('fetchCurrentSession', () => {
 
     expect(useUserStore.getState().selectedActivity).toBeNull();
   });
+
+  it('restores room color from the rooms API when resuming a session', async () => {
+    setAuthenticated();
+    const session: CurrentSession = {
+      active_group_id: 1,
+      activity_id: 10,
+      activity_name: 'Fußball AG',
+      device_id: 1,
+      start_time: '2024-01-01T10:00:00Z',
+      duration: '2h',
+      room_id: 5,
+      room_name: 'Turnhalle',
+      is_active: true,
+    };
+    mockGetCurrentSession.mockResolvedValueOnce(session);
+    mockGetActivities.mockResolvedValueOnce([mockActivity({ id: 10, name: 'Fußball AG' })]);
+    mockGetRooms.mockResolvedValueOnce([
+      mockRoom({ id: 5, name: 'Turnhalle', color: '#F4D35E', is_occupied: false }),
+    ]);
+
+    await useUserStore.getState().fetchCurrentSession();
+
+    expect(mockGetRooms).toHaveBeenCalledWith('1234');
+    expect(useUserStore.getState().selectedRoom).toEqual({
+      id: 5,
+      name: 'Turnhalle',
+      color: '#F4D35E',
+      is_occupied: true,
+    });
+  });
+
+  it('restores room color from cached rooms without fetching', async () => {
+    setAuthenticated();
+    useUserStore.setState({
+      rooms: [mockRoom({ id: 5, name: 'Turnhalle', color: '#2457A6' })],
+    });
+    const session: CurrentSession = {
+      active_group_id: 1,
+      activity_id: 10,
+      activity_name: 'Fußball AG',
+      device_id: 1,
+      start_time: '2024-01-01T10:00:00Z',
+      duration: '2h',
+      room_id: 5,
+      room_name: 'Turnhalle',
+      is_active: true,
+    };
+    mockGetCurrentSession.mockResolvedValueOnce(session);
+    mockGetActivities.mockResolvedValueOnce([mockActivity({ id: 10, name: 'Fußball AG' })]);
+
+    await useUserStore.getState().fetchCurrentSession();
+
+    expect(mockGetRooms).not.toHaveBeenCalled();
+    expect(useUserStore.getState().selectedRoom!.color).toBe('#2457A6');
+  });
+
+  it('fills missing selected room color from cached rooms when IDs match', async () => {
+    setAuthenticated();
+    useUserStore.setState({
+      selectedRoom: mockRoom({ id: 5, name: 'Turnhalle' }),
+      rooms: [mockRoom({ id: 5, name: 'Turnhalle', color: '#AABBCC' })],
+    });
+    const session: CurrentSession = {
+      active_group_id: 1,
+      activity_id: 10,
+      activity_name: 'Fußball AG',
+      device_id: 1,
+      start_time: '2024-01-01T10:00:00Z',
+      duration: '2h',
+      room_id: 5,
+      room_name: 'Turnhalle',
+      is_active: true,
+    };
+    mockGetCurrentSession.mockResolvedValueOnce(session);
+    mockGetActivities.mockResolvedValueOnce([mockActivity({ id: 10, name: 'Fußball AG' })]);
+
+    await useUserStore.getState().fetchCurrentSession();
+
+    expect(mockGetRooms).not.toHaveBeenCalled();
+    expect(useUserStore.getState().selectedRoom!.color).toBe('#AABBCC');
+  });
+
+  it('keeps a fallback room when the rooms API fails during resume', async () => {
+    setAuthenticated();
+    const session: CurrentSession = {
+      active_group_id: 1,
+      activity_id: 10,
+      activity_name: 'Fußball AG',
+      device_id: 1,
+      start_time: '2024-01-01T10:00:00Z',
+      duration: '2h',
+      room_id: 5,
+      room_name: 'Turnhalle',
+      is_active: true,
+    };
+    mockGetCurrentSession.mockResolvedValueOnce(session);
+    mockGetActivities.mockResolvedValueOnce([mockActivity({ id: 10, name: 'Fußball AG' })]);
+    mockGetRooms.mockRejectedValueOnce(new Error('Server error'));
+
+    await useUserStore.getState().fetchCurrentSession();
+
+    expect(useUserStore.getState().selectedRoom).toEqual({
+      id: 5,
+      name: 'Turnhalle',
+      is_occupied: true,
+    });
+  });
 });
 
 // ====================================================================

--- a/src/store/userStore.test.ts
+++ b/src/store/userStore.test.ts
@@ -596,6 +596,59 @@ describe('fetchCurrentSession', () => {
     expect(useUserStore.getState().selectedRoom!.color).toBe('#AABBCC');
   });
 
+  it('does not refetch rooms when the selected room already has a color', async () => {
+    setAuthenticated();
+    useUserStore.setState({
+      selectedRoom: mockRoom({ id: 5, name: 'Turnhalle', color: '#112233' }),
+    });
+    const session: CurrentSession = {
+      active_group_id: 1,
+      activity_id: 10,
+      activity_name: 'Fußball AG',
+      device_id: 1,
+      start_time: '2024-01-01T10:00:00Z',
+      duration: '2h',
+      room_id: 5,
+      room_name: 'Turnhalle',
+      is_active: true,
+    };
+    mockGetCurrentSession.mockResolvedValueOnce(session);
+    mockGetActivities.mockResolvedValueOnce([mockActivity({ id: 10, name: 'Fußball AG' })]);
+
+    await useUserStore.getState().fetchCurrentSession();
+
+    expect(mockGetRooms).not.toHaveBeenCalled();
+    expect(useUserStore.getState().selectedRoom!.color).toBe('#112233');
+  });
+
+  it('retries the rooms lookup when the selected room is missing its color', async () => {
+    setAuthenticated();
+    useUserStore.setState({
+      selectedRoom: mockRoom({ id: 5, name: 'Turnhalle' }),
+    });
+    const session: CurrentSession = {
+      active_group_id: 1,
+      activity_id: 10,
+      activity_name: 'Fußball AG',
+      device_id: 1,
+      start_time: '2024-01-01T10:00:00Z',
+      duration: '2h',
+      room_id: 5,
+      room_name: 'Turnhalle',
+      is_active: true,
+    };
+    mockGetCurrentSession.mockResolvedValueOnce(session);
+    mockGetActivities.mockResolvedValueOnce([mockActivity({ id: 10, name: 'Fußball AG' })]);
+    mockGetRooms.mockResolvedValueOnce([
+      mockRoom({ id: 5, name: 'Turnhalle', color: '#F4D35E', is_occupied: true }),
+    ]);
+
+    await useUserStore.getState().fetchCurrentSession();
+
+    expect(mockGetRooms).toHaveBeenCalledWith('1234');
+    expect(useUserStore.getState().selectedRoom!.color).toBe('#F4D35E');
+  });
+
   it('keeps a fallback room when the rooms API fails during resume', async () => {
     setAuthenticated();
     const session: CurrentSession = {


### PR DESCRIPTION
> **Hinweis:** Beim Wiederherstellen einer laufenden Sitzung lädt der Client fehlende Rauminformationen zusätzlich über die bestehende Raum-API nach. Bitte dieses Verhalten vor dem Merge prüfen.

## Zusammenfassung

- Zeigt die konfigurierte Farbe des ausgewählten Raums als breiten Rahmen mit hellem Einsatz auf dem wartenden Check-in-Bildschirm.
- Der Inhalt bleibt weiß und damit auch bei dunklen Raumfarben lesbar.
- Ohne gültigen sechsstelligen Hex-Wert bleibt der Bildschirm rahmenlos.
- Bei Sitzungswiederherstellung ergänzt der Client eine fehlende Raumfarbe aus zwischengespeicherten Räumen oder über die bestehende Raum-API; bei Fehlern bleibt der bisherige Fallback erhalten.

## Verhalten

| `selectedRoom.color` | Wartender Check-in-Bildschirm |
| --- | --- |
| Gültiger sechsstelliger Hex-Wert | Rahmen in der Raumfarbe, weißer Inhaltsbereich |
| Fehlend, leer oder ungültig | Bestehender Bildschirm ohne Rahmen |

## Tests

- `pnpm run check`
- `pnpm run test`

Closes #399
