### PR TITLE
Fehlermeldung fuer fehlenden Raum auf Deutsch mappen

### DIFF
--- a/src/services/__snapshots__/apiErrors.test.ts.snap
+++ b/src/services/__snapshots__/apiErrors.test.ts.snap
@@ -66,6 +66,10 @@ exports[`ERROR_MESSAGE_MAPPINGS backend contract > keeps all patterns and German
     "Keine aktive Sitzung. Bitte zuerst eine Aktivität starten.",
   ],
   [
+    "no room available",
+    "Für diese Aktivität ist kein Raum hinterlegt. Bitte einen Raum auswählen.",
+  ],
+  [
     "invalid session ID",
     "Ungültige Sitzungs-ID.",
   ],

--- a/src/services/apiErrors.test.ts
+++ b/src/services/apiErrors.test.ts
@@ -18,6 +18,6 @@ describe('ERROR_MESSAGE_MAPPINGS backend contract', () => {
   });
 
   it('keeps the number of mappings stable', () => {
-    expect(ERROR_MESSAGE_MAPPINGS).toHaveLength(55);
+    expect(ERROR_MESSAGE_MAPPINGS).toHaveLength(56);
   });
 });

--- a/src/services/apiErrors.ts
+++ b/src/services/apiErrors.ts
@@ -110,6 +110,11 @@ export const ERROR_MESSAGE_MAPPINGS: readonly ErrorMapping[] = [
   ],
   ['no active session to end', 'Keine aktive Sitzung zum Beenden vorhanden.'],
   ['no active session', 'Keine aktive Sitzung. Bitte zuerst eine Aktivität starten.'],
+  // Backend services/active: no room was sent and the activity has no planned room
+  [
+    'no room available',
+    'Für diese Aktivität ist kein Raum hinterlegt. Bitte einen Raum auswählen.',
+  ],
   ['invalid session ID', 'Ungültige Sitzungs-ID.'],
   ['activity_id is required', 'Aktivität muss ausgewählt werden.'],
   ['at least one supervisor', 'Mindestens ein Betreuer muss ausgewählt werden.'], // Matches both variants


### PR DESCRIPTION
## Was

Neues Mapping in `src/services/apiErrors.ts`:

`'no room available'` → „Für diese Aktivität ist kein Raum hinterlegt. Bitte einen Raum auswählen."

## Warum

Das Backend hatte in `services/active/session_service.go` einen fest verdrahteten Fallback auf Raum-ID 1, wenn beim Sessionstart weder ein Raum mitgeschickt wurde noch die Aktivität einen geplanten Raum hat. Raum 1 gehört genau einer Schule, für jede andere schlug der Fremdschlüssel `fk_active_groups_room_tenant` zu und der Kiosk bekam einen 500er ohne verwertbare Meldung.

Das Backend gibt jetzt `ErrNoRoomAvailable` zurück, gerendert als 400 mit der Meldung `no room available for this activity` (project-phoenix, Branch `test/2419-parallel-sweep`). Ohne dieses Mapping würde der Kiosk nur seinen generischen Fehlertext zeigen.

## Hinweis zum Kontrakt-Test

`src/services/apiErrors.test.ts` pinnt die Anzahl der Mappings. Der Zähler wurde von 55 auf 56 erhöht und der Snapshot aktualisiert, weil ein Mapping bewusst dazugekommen ist.

## Test

- `pnpm vitest run src/services/apiErrors.test.ts` grün
- `pnpm run lint` ohne Befunde